### PR TITLE
feat: updated deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,25 +11,25 @@
       "dependencies": {
         "@js-ak/mysql-migration-system": "1.0.1",
         "@js-ak/pg-migration-system": "1.3.0",
-        "@types/pg": "8.11.2",
-        "mysql2": "3.10.0",
-        "pg": "8.11.3"
+        "@types/pg": "8.11.6",
+        "mysql2": "3.10.1",
+        "pg": "8.12.0"
       },
       "devDependencies": {
         "@semantic-release/changelog": "6.0.3",
-        "@semantic-release/commit-analyzer": "12.0.0",
+        "@semantic-release/commit-analyzer": "13.0.0",
         "@semantic-release/git": "10.0.1",
-        "@semantic-release/github": "10.0.2",
-        "@semantic-release/npm": "12.0.0",
-        "@semantic-release/release-notes-generator": "12.1.0",
-        "@types/node": "20.11.30",
-        "@typescript-eslint/eslint-plugin": "7.3.1",
-        "@typescript-eslint/parser": "7.3.1",
+        "@semantic-release/github": "10.0.6",
+        "@semantic-release/npm": "12.0.1",
+        "@semantic-release/release-notes-generator": "14.0.1",
+        "@types/node": "20.14.8",
+        "@typescript-eslint/eslint-plugin": "7.13.1",
+        "@typescript-eslint/parser": "7.13.1",
         "eslint": "8.57.0",
-        "eslint-plugin-sort-destructure-keys": "1.5.0",
+        "eslint-plugin-sort-destructure-keys": "2.0.0",
         "eslint-plugin-sort-exports": "0.9.1",
-        "semantic-release": "23.0.5",
-        "typescript": "5.4.5"
+        "semantic-release": "24.0.0",
+        "typescript": "5.5.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -103,9 +103,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.6.2.tgz",
-      "integrity": "sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.1.tgz",
+      "integrity": "sha512-Zm2NGpWELsQAD1xsJzGQpYfvICSsFkEpU0jxBjfdC6uNEWXcHnfs9hScFWtXVDVl+rBQJGrl4g1vcKIejpH9dA==",
       "dev": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -159,6 +159,7 @@
       "version": "0.11.14",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
       "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
+      "deprecated": "Use @eslint/config-array instead",
       "dev": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^2.0.2",
@@ -183,9 +184,10 @@
       }
     },
     "node_modules/@humanwhocodes/object-schema": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz",
-      "integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+      "deprecated": "Use @eslint/object-schema instead",
       "dev": true
     },
     "node_modules/@js-ak/mysql-migration-system": {
@@ -294,18 +296,33 @@
       "dev": true
     },
     "node_modules/@octokit/plugin-paginate-rest": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-10.0.0.tgz",
-      "integrity": "sha512-G1Z67qOiFneKDJyMafHQkWnKm1kU3FfbRZLzxgsFg4dOa3pRNdABbdk+xo/oev6P88lnbt7GKdBNB6dJZuPphA==",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.3.0.tgz",
+      "integrity": "sha512-n4znWfRinnUQF6TPyxs7EctSAA3yVSP4qlJP2YgI3g9d4Ae2n5F3XDOjbUluKRxPU3rfsgpOboI4O4VtPc6Ilg==",
       "dev": true,
       "dependencies": {
-        "@octokit/types": "^12.6.0"
+        "@octokit/types": "^13.5.0"
       },
       "engines": {
         "node": ">= 18"
       },
       "peerDependencies": {
         "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
+      "version": "22.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.2.0.tgz",
+      "integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==",
+      "dev": true
+    },
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.5.0.tgz",
+      "integrity": "sha512-HdqWTf5Z3qwDVlzCrP8UJquMwunpDiMPt5er+QjGzL4hqr/vBVY/MauQgS1xWxCDT1oMx1EULyqxncdCY/NVSQ==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/openapi-types": "^22.2.0"
       }
     },
     "node_modules/@octokit/plugin-retry": {
@@ -402,6 +419,12 @@
         "node": ">=12"
       }
     },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "dev": true
+    },
     "node_modules/@semantic-release/changelog": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-6.0.3.tgz",
@@ -421,14 +444,15 @@
       }
     },
     "node_modules/@semantic-release/commit-analyzer": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-12.0.0.tgz",
-      "integrity": "sha512-qG+md5gdes+xa8zP7lIo1fWE17zRdO8yMCaxh9lyL65TQleoSv8WHHOqRURfghTytUh+NpkSyBprQ5hrkxOKVQ==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-13.0.0.tgz",
+      "integrity": "sha512-KtXWczvTAB1ZFZ6B4O+w8HkfYm/OgQb1dUGNFZtDgQ0csggrmkq8sTxhd+lwGF8kMb59/RnG9o4Tn7M/I8dQ9Q==",
       "dev": true,
       "dependencies": {
-        "conventional-changelog-angular": "^7.0.0",
-        "conventional-commits-filter": "^4.0.0",
-        "conventional-commits-parser": "^5.0.0",
+        "conventional-changelog-angular": "^8.0.0",
+        "conventional-changelog-writer": "^8.0.0",
+        "conventional-commits-filter": "^5.0.0",
+        "conventional-commits-parser": "^6.0.0",
         "debug": "^4.0.0",
         "import-from-esm": "^1.0.3",
         "lodash-es": "^4.17.21",
@@ -473,13 +497,13 @@
       }
     },
     "node_modules/@semantic-release/github": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-10.0.2.tgz",
-      "integrity": "sha512-SP5ihhv/uQa8vPuWKmbJrrzfv8lRUkDFC6qwgaWoorrflN1DEW0IGCa9w/PxUp8Ad3dbvXZPmpXdGiP3eyTzhg==",
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-10.0.6.tgz",
+      "integrity": "sha512-sS4psqZacGTFEN49UQGqwFNG6Jyx2/RX1BhhDGn/2WoPbhAHislohOY05/5r+JoL4gJMWycfH7tEm1eGVutYeg==",
       "dev": true,
       "dependencies": {
         "@octokit/core": "^6.0.0",
-        "@octokit/plugin-paginate-rest": "^10.0.0",
+        "@octokit/plugin-paginate-rest": "^11.0.0",
         "@octokit/plugin-retry": "^7.0.0",
         "@octokit/plugin-throttling": "^9.0.0",
         "@semantic-release/error": "^4.0.0",
@@ -611,14 +635,14 @@
       }
     },
     "node_modules/@semantic-release/npm": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-12.0.0.tgz",
-      "integrity": "sha512-72TVYQCH9NvVsO/y13eF8vE4bNnfls518+4KcFwJUKi7AtA/ZXoNgSg9gTTfw5eMZMkiH0izUrpGXgZE/cSQhA==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-12.0.1.tgz",
+      "integrity": "sha512-/6nntGSUGK2aTOI0rHPwY3ZjgY9FkXmEHbW9Kr+62NVOsyqpKKeP0lrCH+tphv+EsNdJNmqqwijTEnVWUMQ2Nw==",
       "dev": true,
       "dependencies": {
         "@semantic-release/error": "^4.0.0",
         "aggregate-error": "^5.0.0",
-        "execa": "^8.0.0",
+        "execa": "^9.0.0",
         "fs-extra": "^11.0.0",
         "lodash-es": "^4.17.21",
         "nerf-dart": "^1.0.0",
@@ -644,6 +668,18 @@
       "dev": true,
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@semantic-release/npm/node_modules/aggregate-error": {
@@ -690,47 +726,54 @@
       }
     },
     "node_modules/@semantic-release/npm/node_modules/execa": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
-      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.2.0.tgz",
+      "integrity": "sha512-vpOyYg7UAVKLAWWtRS2gAdgkT7oJbCn0me3gmUmxZih4kd3MF/oo8kNTBTIbkO3yuuF5uB4ZCZfn8BOolITYhg==",
       "dev": true,
       "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
         "cross-spawn": "^7.0.3",
-        "get-stream": "^8.0.1",
-        "human-signals": "^5.0.0",
-        "is-stream": "^3.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^5.1.0",
-        "onetime": "^6.0.0",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^7.0.0",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^5.2.0",
+        "pretty-ms": "^9.0.0",
         "signal-exit": "^4.1.0",
-        "strip-final-newline": "^3.0.0"
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.0.0"
       },
       "engines": {
-        "node": ">=16.17"
+        "node": "^18.19.0 || >=20.5.0"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
     "node_modules/@semantic-release/npm/node_modules/get-stream": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
-      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
       "dev": true,
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@semantic-release/npm/node_modules/human-signals": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
-      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-7.0.0.tgz",
+      "integrity": "sha512-74kytxOUSvNbjrT9KisAbaTZ/eJwD/LrbM/kh5j0IhPuJzwuA19dWvniFGwBzN9rVjg+O/e+F310PjObDXS+9Q==",
       "dev": true,
       "engines": {
-        "node": ">=16.17.0"
+        "node": ">=18.18.0"
       }
     },
     "node_modules/@semantic-release/npm/node_modules/indent-string": {
@@ -746,54 +789,27 @@
       }
     },
     "node_modules/@semantic-release/npm/node_modules/is-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
       "dev": true,
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@semantic-release/npm/node_modules/mimic-fn": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@semantic-release/npm/node_modules/npm-run-path": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
-      "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
       "dev": true,
       "dependencies": {
         "path-key": "^4.0.0"
       },
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@semantic-release/npm/node_modules/onetime": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-      "dev": true,
-      "dependencies": {
-        "mimic-fn": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -824,36 +840,36 @@
       }
     },
     "node_modules/@semantic-release/npm/node_modules/strip-final-newline": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
       "dev": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@semantic-release/release-notes-generator": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-12.1.0.tgz",
-      "integrity": "sha512-g6M9AjUKAZUZnxaJZnouNBeDNTCUrJ5Ltj+VJ60gJeDaRRahcHsry9HW8yKrnKkKNkx5lbWiEP1FPMqVNQz8Kg==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-14.0.1.tgz",
+      "integrity": "sha512-K0w+5220TM4HZTthE5dDpIuFrnkN1NfTGPidJFm04ULT1DEZ9WG89VNXN7F0c+6nMEpWgqmPvb7vY7JkB2jyyA==",
       "dev": true,
       "dependencies": {
-        "conventional-changelog-angular": "^7.0.0",
-        "conventional-changelog-writer": "^7.0.0",
-        "conventional-commits-filter": "^4.0.0",
-        "conventional-commits-parser": "^5.0.0",
+        "conventional-changelog-angular": "^8.0.0",
+        "conventional-changelog-writer": "^8.0.0",
+        "conventional-commits-filter": "^5.0.0",
+        "conventional-commits-parser": "^6.0.0",
         "debug": "^4.0.0",
         "get-stream": "^7.0.0",
         "import-from-esm": "^1.0.3",
         "into-stream": "^7.0.0",
         "lodash-es": "^4.17.21",
-        "read-pkg-up": "^11.0.0"
+        "read-package-up": "^11.0.0"
       },
       "engines": {
-        "node": "^18.17 || >=20.6.1"
+        "node": ">=20.8.1"
       },
       "peerDependencies": {
         "semantic-release": ">=20.1.0"
@@ -895,16 +911,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@types/json-schema": {
-      "version": "7.0.15",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true
-    },
     "node_modules/@types/node": {
-      "version": "20.11.30",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.30.tgz",
-      "integrity": "sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==",
+      "version": "20.14.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.8.tgz",
+      "integrity": "sha512-DO+2/jZinXfROG7j7WKFn/3C6nFwxy2lLpgLjEXJz+0XKphZlTLJ14mo8Vfg8X5BWN6XjyESXq+LcYdT7tR3bA==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -916,9 +926,9 @@
       "dev": true
     },
     "node_modules/@types/pg": {
-      "version": "8.11.2",
-      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.11.2.tgz",
-      "integrity": "sha512-G2Mjygf2jFMU/9hCaTYxJrwdObdcnuQde1gndooZSOHsNSaCehAuwc7EIuSA34Do8Jx2yZ19KtvW8P0j4EuUXw==",
+      "version": "8.11.6",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.11.6.tgz",
+      "integrity": "sha512-/2WmmBXHLsfRqzfHW7BNZ8SbYzE8OSk7i3WjFYvfgRHj7S1xj+16Je5fUKv3lVdVzk/zn9TXOqf+avFCFIE0yQ==",
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
@@ -984,22 +994,20 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.3.1.tgz",
-      "integrity": "sha512-STEDMVQGww5lhCuNXVSQfbfuNII5E08QWkvAw5Qwf+bj2WT+JkG1uc+5/vXA3AOYMDHVOSpL+9rcbEUiHIm2dw==",
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.13.1.tgz",
+      "integrity": "sha512-kZqi+WZQaZfPKnsflLJQCz6Ze9FFSMfXrrIOcyargekQxG37ES7DJNpJUE9Q/X5n3yTIP/WPutVNzgknQ7biLg==",
       "dev": true,
       "dependencies": {
-        "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "7.3.1",
-        "@typescript-eslint/type-utils": "7.3.1",
-        "@typescript-eslint/utils": "7.3.1",
-        "@typescript-eslint/visitor-keys": "7.3.1",
-        "debug": "^4.3.4",
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "7.13.1",
+        "@typescript-eslint/type-utils": "7.13.1",
+        "@typescript-eslint/utils": "7.13.1",
+        "@typescript-eslint/visitor-keys": "7.13.1",
         "graphemer": "^1.4.0",
-        "ignore": "^5.2.4",
+        "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
+        "ts-api-utils": "^1.3.0"
       },
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -1018,16 +1026,65 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/parser": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.3.1.tgz",
-      "integrity": "sha512-Rq49+pq7viTRCH48XAbTA+wdLRrB/3sRq4Lpk0oGDm0VmnjBrAOVXH/Laalmwsv2VpekiEfVFwJYVk6/e8uvQw==",
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/type-utils": {
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.13.1.tgz",
+      "integrity": "sha512-aWDbLu1s9bmgPGXSzNCxELu+0+HQOapV/y+60gPXafR8e2g1Bifxzevaa+4L2ytCWm+CHqpELq4CSoN9ELiwCg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "7.3.1",
-        "@typescript-eslint/types": "7.3.1",
-        "@typescript-eslint/typescript-estree": "7.3.1",
-        "@typescript-eslint/visitor-keys": "7.3.1",
+        "@typescript-eslint/typescript-estree": "7.13.1",
+        "@typescript-eslint/utils": "7.13.1",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.13.1.tgz",
+      "integrity": "sha512-h5MzFBD5a/Gh/fvNdp9pTfqJAbuQC4sCN2WzuXme71lqFJsZtLbjxfSk4r3p02WIArOF9N94pdsLiGutpDbrXQ==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@typescript-eslint/scope-manager": "7.13.1",
+        "@typescript-eslint/types": "7.13.1",
+        "@typescript-eslint/typescript-estree": "7.13.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.13.1.tgz",
+      "integrity": "sha512-1ELDPlnLvDQ5ybTSrMhRTFDfOQEOXNM+eP+3HT/Yq7ruWpciQw+Avi73pdEbA4SooCawEWo3dtYbF68gN7Ed1A==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "7.13.1",
+        "@typescript-eslint/types": "7.13.1",
+        "@typescript-eslint/typescript-estree": "7.13.1",
+        "@typescript-eslint/visitor-keys": "7.13.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1047,13 +1104,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.3.1.tgz",
-      "integrity": "sha512-fVS6fPxldsKY2nFvyT7IP78UO1/I2huG+AYu5AMjCT9wtl6JFiDnsv4uad4jQ0GTFzcUV5HShVeN96/17bTBag==",
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.13.1.tgz",
+      "integrity": "sha512-adbXNVEs6GmbzaCpymHQ0MB6E4TqoiVbC0iqG3uijR8ZYfpAXMGttouQzF4Oat3P2GxDVIrg7bMI/P65LiQZdg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.3.1",
-        "@typescript-eslint/visitor-keys": "7.3.1"
+        "@typescript-eslint/types": "7.13.1",
+        "@typescript-eslint/visitor-keys": "7.13.1"
       },
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -1061,39 +1118,12 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.3.1.tgz",
-      "integrity": "sha512-iFhaysxFsMDQlzJn+vr3OrxN8NmdQkHks4WaqD4QBnt5hsq234wcYdyQ9uquzJJIDAj5W4wQne3yEsYA6OmXGw==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/typescript-estree": "7.3.1",
-        "@typescript-eslint/utils": "7.3.1",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^1.0.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.56.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.3.1.tgz",
-      "integrity": "sha512-2tUf3uWggBDl4S4183nivWQ2HqceOZh1U4hhu4p1tPiIJoRRXrab7Y+Y0p+dozYwZVvLPRI6r5wKe9kToF9FIw==",
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.13.1.tgz",
+      "integrity": "sha512-7K7HMcSQIAND6RBL4kDl24sG/xKM13cA85dc7JnmQXw2cBDngg7c19B++JzvJHRG3zG36n9j1i451GBzRuHchw==",
       "dev": true,
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -1104,19 +1134,19 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.3.1.tgz",
-      "integrity": "sha512-tLpuqM46LVkduWP7JO7yVoWshpJuJzxDOPYIVWUUZbW+4dBpgGeUdl/fQkhuV0A8eGnphYw3pp8d2EnvPOfxmQ==",
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.13.1.tgz",
+      "integrity": "sha512-uxNr51CMV7npU1BxZzYjoVz9iyjckBduFBP0S5sLlh1tXYzHzgZ3BR9SVsNed+LmwKrmnqN3Kdl5t7eZ5TS1Yw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.3.1",
-        "@typescript-eslint/visitor-keys": "7.3.1",
+        "@typescript-eslint/types": "7.13.1",
+        "@typescript-eslint/visitor-keys": "7.13.1",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
-        "minimatch": "9.0.3",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^1.3.0"
       },
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -1141,9 +1171,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -1155,39 +1185,14 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@typescript-eslint/utils": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.3.1.tgz",
-      "integrity": "sha512-jIERm/6bYQ9HkynYlNZvXpzmXWZGhMbrOvq3jJzOSOlKXsVjrrolzWBjDW6/TvT5Q3WqaN4EkmcfdQwi9tDjBQ==",
-      "dev": true,
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "@types/json-schema": "^7.0.12",
-        "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "7.3.1",
-        "@typescript-eslint/types": "7.3.1",
-        "@typescript-eslint/typescript-estree": "7.3.1",
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.56.0"
-      }
-    },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.3.1.tgz",
-      "integrity": "sha512-9RMXwQF8knsZvfv9tdi+4D/j7dMG28X/wMJ8Jj6eOHyHWwDW4ngQJcqEczSsqIKKjFiLFr40Mnr7a5ulDD3vmw==",
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.13.1.tgz",
+      "integrity": "sha512-k/Bfne7lrP7hcb7m9zSsgcBmo+8eicqqfNAJ7uUY+jkTFpKeH2FSkWpFRtimBxgkyvqfu9jTPRbYOvud6isdXA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.3.1",
-        "eslint-visitor-keys": "^3.4.1"
+        "@typescript-eslint/types": "7.13.1",
+        "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -1204,9 +1209,9 @@
       "dev": true
     },
     "node_modules/acorn": {
-      "version": "8.11.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.0.tgz",
+      "integrity": "sha512-RTvkC4w+KNXrM39/lWCUaG0IbRkWdCv7W/IOW9oU6SawyxulvkQy5HQPVTKxEjczcUvapcrw3cFx/60VN/NRNw==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -1375,23 +1380,15 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/buffer-writer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
-      "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/callsites": {
@@ -1626,62 +1623,70 @@
       }
     },
     "node_modules/conventional-changelog-angular": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz",
-      "integrity": "sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.0.0.tgz",
+      "integrity": "sha512-CLf+zr6St0wIxos4bmaKHRXWAcsCXrJU6F4VdNDrGRK3B8LDLKoX3zuMV5GhtbGkVR/LohZ6MT6im43vZLSjmA==",
       "dev": true,
       "dependencies": {
         "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/conventional-changelog-writer": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-7.0.1.tgz",
-      "integrity": "sha512-Uo+R9neH3r/foIvQ0MKcsXkX642hdm9odUp7TqgFS7BsalTcjzRlIfWZrZR1gbxOozKucaKt5KAbjW8J8xRSmA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-8.0.0.tgz",
+      "integrity": "sha512-TQcoYGRatlAnT2qEWDON/XSfnVG38JzA7E0wcGScu7RElQBkg9WWgZd1peCWFcWDh1xfb2CfsrcvOn1bbSzztA==",
       "dev": true,
       "dependencies": {
-        "conventional-commits-filter": "^4.0.0",
+        "@types/semver": "^7.5.5",
+        "conventional-commits-filter": "^5.0.0",
         "handlebars": "^4.7.7",
-        "json-stringify-safe": "^5.0.1",
-        "meow": "^12.0.1",
-        "semver": "^7.5.2",
-        "split2": "^4.0.0"
+        "meow": "^13.0.0",
+        "semver": "^7.5.2"
       },
       "bin": {
-        "conventional-changelog-writer": "cli.mjs"
+        "conventional-changelog-writer": "dist/cli/index.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/conventional-commits-filter": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-4.0.0.tgz",
-      "integrity": "sha512-rnpnibcSOdFcdclpFwWa+pPlZJhXE7l+XK04zxhbWrhgpR96h33QLz8hITTXbcYICxVr3HZFtbtUAQ+4LdBo9A==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
+      "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
       "dev": true,
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/conventional-commits-parser": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-5.0.0.tgz",
-      "integrity": "sha512-ZPMl0ZJbw74iS9LuX9YIAiW8pfM5p3yh2o/NbXHbkFuZzY5jvdi5jFycEOkmBW5H5I7nA+D6f3UcsCLP2vvSEA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.0.0.tgz",
+      "integrity": "sha512-TbsINLp48XeMXR8EvGjTnKGsZqBemisPoyWESlpRyR8lif0lcwzqz+NMtYSj1ooF/WYjSuu7wX0CtdeeMEQAmA==",
       "dev": true,
       "dependencies": {
-        "is-text-path": "^2.0.0",
-        "JSONStream": "^1.3.5",
-        "meow": "^12.0.1",
-        "split2": "^4.0.0"
+        "meow": "^13.0.0"
       },
       "bin": {
-        "conventional-commits-parser": "cli.mjs"
+        "conventional-commits-parser": "dist/cli/index.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-hrtime": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-5.0.0.tgz",
+      "integrity": "sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/core-util-is": {
@@ -2093,18 +2098,18 @@
       }
     },
     "node_modules/eslint-plugin-sort-destructure-keys": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-sort-destructure-keys/-/eslint-plugin-sort-destructure-keys-1.5.0.tgz",
-      "integrity": "sha512-xGLyqHtbFXZNXQSvAiQ4ISBYokrbUywEhmaA50fKtSKgceCv5y3zjoNuZwcnajdM6q29Nxj+oXC9KcqfMsAPrg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-sort-destructure-keys/-/eslint-plugin-sort-destructure-keys-2.0.0.tgz",
+      "integrity": "sha512-4w1UQCa3o/YdfWaLr9jY8LfGowwjwjmwClyFLxIsToiyIdZMq3x9Ti44nDn34DtTPP7PWg96tUONKVmATKhYGQ==",
       "dev": true,
       "dependencies": {
         "natural-compare-lite": "^1.4.0"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=12"
       },
       "peerDependencies": {
-        "eslint": "3 - 8"
+        "eslint": "5 - 9"
       }
     },
     "node_modules/eslint-plugin-sort-exports": {
@@ -2141,6 +2146,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint-visitor-keys": {
@@ -2214,31 +2235,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint/node_modules/eslint-scope": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
-      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
-      "dev": true,
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^5.2.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.0"
       }
     },
     "node_modules/eslint/node_modules/find-up": {
@@ -2376,15 +2372,6 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/esquery/node_modules/estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "node_modules/esrecurse": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
@@ -2397,7 +2384,7 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/esrecurse/node_modules/estraverse": {
+    "node_modules/estraverse": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
@@ -2509,9 +2496,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -2533,27 +2520,29 @@
       }
     },
     "node_modules/find-versions": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-5.1.0.tgz",
-      "integrity": "sha512-+iwzCJ7C5v5KgcBuueqVoNiHVoQpwiUK5XFLjf0affFTep+Wcw93tPvmb8tqujDNmzhBDPddnWV/qgWSXgq+Hg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-6.0.0.tgz",
+      "integrity": "sha512-2kCCtc+JvcZ86IGAz3Z2Y0A1baIz9fL31pH/0S1IqZr9Iwnjq8izfPtrCyQKO6TLMPELLsQMre7VDqeIKCsHkA==",
       "dev": true,
       "dependencies": {
-        "semver-regex": "^4.0.5"
+        "semver-regex": "^4.0.5",
+        "super-regex": "^1.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/flat-cache": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
-      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
       "dev": true,
       "dependencies": {
-        "flatted": "^3.1.0",
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.3",
         "rimraf": "^3.0.2"
       },
       "engines": {
@@ -2561,9 +2550,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
-      "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
+      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
     },
     "node_modules/from2": {
@@ -2601,6 +2590,18 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
+    },
+    "node_modules/function-timeout": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/function-timeout/-/function-timeout-1.0.2.tgz",
+      "integrity": "sha512-939eZS4gJ3htTHAldmyyuzlrD58P03fHG49v2JfFXbV6OhvZKRC9j2yAtdHw/zrp2zXHuv05zMIy40F0ge7spA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/generate-function": {
       "version": "2.3.1",
@@ -2668,6 +2669,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
       "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -2874,9 +2876,9 @@
       }
     },
     "node_modules/ignore": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
+      "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
       "dev": true,
       "engines": {
         "node": ">= 4"
@@ -2964,6 +2966,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
       "dev": true,
       "dependencies": {
         "once": "^1.3.0",
@@ -3073,6 +3076,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-property": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
@@ -3088,18 +3103,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-text-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-2.0.0.tgz",
-      "integrity": "sha512-+oDTluR6WEjdXEJMnC2z6A4FRwFoYuvShVVEGsS7ewc0UTi2QtAKMDJuL4BDEVt+5T7MjFo12RP8ghOM75oKJw==",
-      "dev": true,
-      "dependencies": {
-        "text-extensions": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-unicode-supported": {
@@ -3169,6 +3172,12 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true
+    },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -3193,12 +3202,6 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
-    "node_modules/json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "dev": true
-    },
     "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -3211,29 +3214,13 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "node_modules/jsonparse": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
-      "dev": true,
-      "engines": [
-        "node >= 0.2.0"
-      ]
-    },
-    "node_modules/JSONStream": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
-      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
       "dependencies": {
-        "jsonparse": "^1.2.0",
-        "through": ">=2.2.7 <3"
-      },
-      "bin": {
-        "JSONStream": "bin.js"
-      },
-      "engines": {
-        "node": "*"
+        "json-buffer": "3.0.1"
       }
     },
     "node_modules/levn": {
@@ -3336,18 +3323,6 @@
       "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
       "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
     },
-    "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/marked": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
@@ -3394,12 +3369,12 @@
       }
     },
     "node_modules/meow": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
-      "integrity": "sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+      "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
       "dev": true,
       "engines": {
-        "node": ">=16.10"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3485,9 +3460,9 @@
       "dev": true
     },
     "node_modules/mysql2": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.10.0.tgz",
-      "integrity": "sha512-qx0mfWYt1DpTPkw8mAcHW/OwqqyNqBLBHvY5IjN8+icIYTjt6znrgYJ+gxqNNRpVknb5Wc/gcCM4XjbCR0j5tw==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.10.1.tgz",
+      "integrity": "sha512-6zo1T3GILsXMCex3YEu7hCz2OXLUarxFsxvFcUHWMpkPtmZLeTTWgRdc1gWyNJiYt6AxITmIf9bZDRy/jAfWew==",
       "dependencies": {
         "denque": "^2.1.0",
         "generate-function": "^2.3.1",
@@ -3607,9 +3582,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-10.5.0.tgz",
-      "integrity": "sha512-Ejxwvfh9YnWVU2yA5FzoYLTW52vxHCz+MHrOFg9Cc8IFgF/6f5AGPAvb5WTay5DIUP1NIfN3VBZ0cLlGO0Ys+A==",
+      "version": "10.8.1",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-10.8.1.tgz",
+      "integrity": "sha512-Dp1C6SvSMYQI7YHq/y2l94uvI+59Eqbu1EpuKQHQ8p16txXRuRit5gH3Lnaagk2aXDIjg/Iru9pd05bnneKgdw==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -3618,6 +3593,7 @@
         "@npmcli/map-workspaces",
         "@npmcli/package-json",
         "@npmcli/promise-spawn",
+        "@npmcli/redact",
         "@npmcli/run-script",
         "@sigstore/tuf",
         "abbrev",
@@ -3626,8 +3602,6 @@
         "chalk",
         "ci-info",
         "cli-columns",
-        "cli-table3",
-        "columnify",
         "fastest-levenshtein",
         "fs-minipass",
         "glob",
@@ -3663,7 +3637,6 @@
         "npm-profile",
         "npm-registry-fetch",
         "npm-user-validate",
-        "npmlog",
         "p-map",
         "pacote",
         "parse-conflict-json",
@@ -3685,73 +3658,71 @@
       "dev": true,
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^7.2.1",
-        "@npmcli/config": "^8.0.2",
-        "@npmcli/fs": "^3.1.0",
-        "@npmcli/map-workspaces": "^3.0.4",
-        "@npmcli/package-json": "^5.0.0",
-        "@npmcli/promise-spawn": "^7.0.1",
-        "@npmcli/run-script": "^7.0.4",
-        "@sigstore/tuf": "^2.3.1",
+        "@npmcli/arborist": "^7.5.3",
+        "@npmcli/config": "^8.3.3",
+        "@npmcli/fs": "^3.1.1",
+        "@npmcli/map-workspaces": "^3.0.6",
+        "@npmcli/package-json": "^5.1.1",
+        "@npmcli/promise-spawn": "^7.0.2",
+        "@npmcli/redact": "^2.0.0",
+        "@npmcli/run-script": "^8.1.0",
+        "@sigstore/tuf": "^2.3.4",
         "abbrev": "^2.0.0",
         "archy": "~1.0.0",
-        "cacache": "^18.0.2",
+        "cacache": "^18.0.3",
         "chalk": "^5.3.0",
         "ci-info": "^4.0.0",
         "cli-columns": "^4.0.0",
-        "cli-table3": "^0.6.3",
-        "columnify": "^1.6.0",
         "fastest-levenshtein": "^1.0.16",
         "fs-minipass": "^3.0.3",
-        "glob": "^10.3.10",
+        "glob": "^10.4.1",
         "graceful-fs": "^4.2.11",
-        "hosted-git-info": "^7.0.1",
-        "ini": "^4.1.1",
-        "init-package-json": "^6.0.0",
-        "is-cidr": "^5.0.3",
-        "json-parse-even-better-errors": "^3.0.1",
-        "libnpmaccess": "^8.0.1",
-        "libnpmdiff": "^6.0.3",
-        "libnpmexec": "^7.0.4",
-        "libnpmfund": "^5.0.1",
-        "libnpmhook": "^10.0.0",
-        "libnpmorg": "^6.0.1",
-        "libnpmpack": "^6.0.3",
-        "libnpmpublish": "^9.0.2",
-        "libnpmsearch": "^7.0.0",
-        "libnpmteam": "^6.0.0",
-        "libnpmversion": "^5.0.1",
-        "make-fetch-happen": "^13.0.0",
-        "minimatch": "^9.0.3",
-        "minipass": "^7.0.4",
+        "hosted-git-info": "^7.0.2",
+        "ini": "^4.1.3",
+        "init-package-json": "^6.0.3",
+        "is-cidr": "^5.1.0",
+        "json-parse-even-better-errors": "^3.0.2",
+        "libnpmaccess": "^8.0.6",
+        "libnpmdiff": "^6.1.3",
+        "libnpmexec": "^8.1.2",
+        "libnpmfund": "^5.0.11",
+        "libnpmhook": "^10.0.5",
+        "libnpmorg": "^6.0.6",
+        "libnpmpack": "^7.0.3",
+        "libnpmpublish": "^9.0.9",
+        "libnpmsearch": "^7.0.6",
+        "libnpmteam": "^6.0.5",
+        "libnpmversion": "^6.0.3",
+        "make-fetch-happen": "^13.0.1",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.1",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
-        "node-gyp": "^10.0.1",
-        "nopt": "^7.2.0",
-        "normalize-package-data": "^6.0.0",
+        "node-gyp": "^10.1.0",
+        "nopt": "^7.2.1",
+        "normalize-package-data": "^6.0.1",
         "npm-audit-report": "^5.0.0",
         "npm-install-checks": "^6.3.0",
-        "npm-package-arg": "^11.0.1",
-        "npm-pick-manifest": "^9.0.0",
-        "npm-profile": "^9.0.0",
-        "npm-registry-fetch": "^16.1.0",
-        "npm-user-validate": "^2.0.0",
-        "npmlog": "^7.0.1",
+        "npm-package-arg": "^11.0.2",
+        "npm-pick-manifest": "^9.0.1",
+        "npm-profile": "^10.0.0",
+        "npm-registry-fetch": "^17.0.1",
+        "npm-user-validate": "^2.0.1",
         "p-map": "^4.0.0",
-        "pacote": "^17.0.6",
+        "pacote": "^18.0.6",
         "parse-conflict-json": "^3.0.1",
-        "proc-log": "^3.0.0",
+        "proc-log": "^4.2.0",
         "qrcode-terminal": "^0.12.0",
-        "read": "^2.1.0",
-        "semver": "^7.6.0",
-        "spdx-expression-parse": "^3.0.1",
-        "ssri": "^10.0.5",
+        "read": "^3.0.1",
+        "semver": "^7.6.2",
+        "spdx-expression-parse": "^4.0.0",
+        "ssri": "^10.0.6",
         "supports-color": "^9.4.0",
-        "tar": "^6.2.0",
+        "tar": "^6.2.1",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^1.3.0",
         "treeverse": "^3.0.0",
-        "validate-npm-package-name": "^5.0.0",
+        "validate-npm-package-name": "^5.0.1",
         "which": "^4.0.0",
         "write-file-atomic": "^5.0.1"
       },
@@ -3773,16 +3744,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/@colors/colors": {
-      "version": "1.5.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.1.90"
       }
     },
     "node_modules/npm/node_modules/@isaacs/cliui": {
@@ -3859,7 +3820,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/agent": {
-      "version": "2.2.1",
+      "version": "2.2.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -3868,49 +3829,51 @@
         "http-proxy-agent": "^7.0.0",
         "https-proxy-agent": "^7.0.1",
         "lru-cache": "^10.0.1",
-        "socks-proxy-agent": "^8.0.1"
+        "socks-proxy-agent": "^8.0.3"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "7.4.0",
+      "version": "7.5.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/fs": "^3.1.0",
-        "@npmcli/installed-package-contents": "^2.0.2",
+        "@npmcli/fs": "^3.1.1",
+        "@npmcli/installed-package-contents": "^2.1.0",
         "@npmcli/map-workspaces": "^3.0.2",
-        "@npmcli/metavuln-calculator": "^7.0.0",
+        "@npmcli/metavuln-calculator": "^7.1.1",
         "@npmcli/name-from-folder": "^2.0.0",
         "@npmcli/node-gyp": "^3.0.0",
-        "@npmcli/package-json": "^5.0.0",
+        "@npmcli/package-json": "^5.1.0",
         "@npmcli/query": "^3.1.0",
-        "@npmcli/run-script": "^7.0.2",
-        "bin-links": "^4.0.1",
-        "cacache": "^18.0.0",
+        "@npmcli/redact": "^2.0.0",
+        "@npmcli/run-script": "^8.1.0",
+        "bin-links": "^4.0.4",
+        "cacache": "^18.0.3",
         "common-ancestor-path": "^1.0.1",
-        "hosted-git-info": "^7.0.1",
-        "json-parse-even-better-errors": "^3.0.0",
+        "hosted-git-info": "^7.0.2",
+        "json-parse-even-better-errors": "^3.0.2",
         "json-stringify-nice": "^1.1.4",
-        "minimatch": "^9.0.0",
-        "nopt": "^7.0.0",
+        "lru-cache": "^10.2.2",
+        "minimatch": "^9.0.4",
+        "nopt": "^7.2.1",
         "npm-install-checks": "^6.2.0",
-        "npm-package-arg": "^11.0.1",
-        "npm-pick-manifest": "^9.0.0",
-        "npm-registry-fetch": "^16.0.0",
-        "npmlog": "^7.0.1",
-        "pacote": "^17.0.4",
+        "npm-package-arg": "^11.0.2",
+        "npm-pick-manifest": "^9.0.1",
+        "npm-registry-fetch": "^17.0.1",
+        "pacote": "^18.0.6",
         "parse-conflict-json": "^3.0.0",
-        "proc-log": "^3.0.0",
+        "proc-log": "^4.2.0",
+        "proggy": "^2.0.0",
         "promise-all-reject-late": "^1.0.0",
         "promise-call-limit": "^3.0.1",
         "read-package-json-fast": "^3.0.2",
         "semver": "^7.3.7",
-        "ssri": "^10.0.5",
+        "ssri": "^10.0.6",
         "treeverse": "^3.0.0",
         "walk-up-path": "^3.0.1"
       },
@@ -3922,16 +3885,16 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "8.2.0",
+      "version": "8.3.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/map-workspaces": "^3.0.2",
         "ci-info": "^4.0.0",
-        "ini": "^4.1.0",
-        "nopt": "^7.0.0",
-        "proc-log": "^3.0.0",
+        "ini": "^4.1.2",
+        "nopt": "^7.2.1",
+        "proc-log": "^4.2.0",
         "read-package-json-fast": "^3.0.2",
         "semver": "^7.3.5",
         "walk-up-path": "^3.0.1"
@@ -3940,35 +3903,8 @@
         "node": "^16.14.0 || >=18.0.0"
       }
     },
-    "node_modules/npm/node_modules/@npmcli/disparity-colors": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "ansi-styles": "^4.3.0"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/disparity-colors/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/npm/node_modules/@npmcli/fs": {
-      "version": "3.1.0",
+      "version": "3.1.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -3980,7 +3916,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/git": {
-      "version": "5.0.4",
+      "version": "5.0.7",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -3988,7 +3924,7 @@
         "@npmcli/promise-spawn": "^7.0.0",
         "lru-cache": "^10.0.1",
         "npm-pick-manifest": "^9.0.0",
-        "proc-log": "^3.0.0",
+        "proc-log": "^4.0.0",
         "promise-inflight": "^1.0.1",
         "promise-retry": "^2.0.1",
         "semver": "^7.3.5",
@@ -3999,7 +3935,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/installed-package-contents": {
-      "version": "2.0.2",
+      "version": "2.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -4008,14 +3944,14 @@
         "npm-normalize-package-bin": "^3.0.0"
       },
       "bin": {
-        "installed-package-contents": "lib/index.js"
+        "installed-package-contents": "bin/index.js"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/map-workspaces": {
-      "version": "3.0.4",
+      "version": "3.0.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -4030,14 +3966,15 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
-      "version": "7.0.0",
+      "version": "7.1.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "cacache": "^18.0.0",
         "json-parse-even-better-errors": "^3.0.0",
-        "pacote": "^17.0.0",
+        "pacote": "^18.0.0",
+        "proc-log": "^4.1.0",
         "semver": "^7.3.5"
       },
       "engines": {
@@ -4063,7 +4000,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/package-json": {
-      "version": "5.0.0",
+      "version": "5.1.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -4073,7 +4010,7 @@
         "hosted-git-info": "^7.0.0",
         "json-parse-even-better-errors": "^3.0.0",
         "normalize-package-data": "^6.0.0",
-        "proc-log": "^3.0.0",
+        "proc-log": "^4.0.0",
         "semver": "^7.5.3"
       },
       "engines": {
@@ -4081,7 +4018,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/promise-spawn": {
-      "version": "7.0.1",
+      "version": "7.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -4104,8 +4041,17 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/npm/node_modules/@npmcli/redact": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
     "node_modules/npm/node_modules/@npmcli/run-script": {
-      "version": "7.0.4",
+      "version": "8.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -4114,6 +4060,7 @@
         "@npmcli/package-json": "^5.0.0",
         "@npmcli/promise-spawn": "^7.0.0",
         "node-gyp": "^10.0.0",
+        "proc-log": "^4.0.0",
         "which": "^4.0.0"
       },
       "engines": {
@@ -4131,19 +4078,19 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/bundle": {
-      "version": "2.2.0",
+      "version": "2.3.2",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@sigstore/protobuf-specs": "^0.3.0"
+        "@sigstore/protobuf-specs": "^0.3.2"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/@sigstore/core": {
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -4152,51 +4099,53 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
-      "version": "0.3.0",
+      "version": "0.3.2",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/@sigstore/sign": {
-      "version": "2.2.3",
+      "version": "2.3.2",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@sigstore/bundle": "^2.2.0",
+        "@sigstore/bundle": "^2.3.2",
         "@sigstore/core": "^1.0.0",
-        "@sigstore/protobuf-specs": "^0.3.0",
-        "make-fetch-happen": "^13.0.0"
+        "@sigstore/protobuf-specs": "^0.3.2",
+        "make-fetch-happen": "^13.0.1",
+        "proc-log": "^4.2.0",
+        "promise-retry": "^2.0.1"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/@sigstore/tuf": {
-      "version": "2.3.1",
+      "version": "2.3.4",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@sigstore/protobuf-specs": "^0.3.0",
-        "tuf-js": "^2.2.0"
+        "@sigstore/protobuf-specs": "^0.3.2",
+        "tuf-js": "^2.2.1"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/@sigstore/verify": {
-      "version": "1.1.0",
+      "version": "1.2.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@sigstore/bundle": "^2.2.0",
-        "@sigstore/core": "^1.0.0",
-        "@sigstore/protobuf-specs": "^0.3.0"
+        "@sigstore/bundle": "^2.3.2",
+        "@sigstore/core": "^1.1.0",
+        "@sigstore/protobuf-specs": "^0.3.2"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
@@ -4212,13 +4161,13 @@
       }
     },
     "node_modules/npm/node_modules/@tufjs/models": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "@tufjs/canonical-json": "2.0.0",
-        "minimatch": "^9.0.3"
+        "minimatch": "^9.0.4"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
@@ -4234,7 +4183,7 @@
       }
     },
     "node_modules/npm/node_modules/agent-base": {
-      "version": "7.1.0",
+      "version": "7.1.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -4291,15 +4240,6 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/are-we-there-yet": {
-      "version": "4.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
     "node_modules/npm/node_modules/balanced-match": {
       "version": "1.0.2",
       "dev": true,
@@ -4307,7 +4247,7 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/bin-links": {
-      "version": "4.0.3",
+      "version": "4.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -4322,12 +4262,15 @@
       }
     },
     "node_modules/npm/node_modules/binary-extensions": {
-      "version": "2.2.0",
+      "version": "2.3.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/npm/node_modules/brace-expansion": {
@@ -4339,17 +4282,8 @@
         "balanced-match": "^1.0.0"
       }
     },
-    "node_modules/npm/node_modules/builtins": {
-      "version": "5.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.0.0"
-      }
-    },
     "node_modules/npm/node_modules/cacache": {
-      "version": "18.0.2",
+      "version": "18.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -4408,7 +4342,7 @@
       }
     },
     "node_modules/npm/node_modules/cidr-regex": {
-      "version": "4.0.3",
+      "version": "4.1.1",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -4441,32 +4375,8 @@
         "node": ">= 10"
       }
     },
-    "node_modules/npm/node_modules/cli-table3": {
-      "version": "0.6.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "string-width": "^4.2.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      },
-      "optionalDependencies": {
-        "@colors/colors": "1.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/clone": {
-      "version": "1.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/npm/node_modules/cmd-shim": {
-      "version": "6.0.2",
+      "version": "6.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -4492,36 +4402,8 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/color-support": {
-      "version": "1.1.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "color-support": "bin.js"
-      }
-    },
-    "node_modules/npm/node_modules/columnify": {
-      "version": "1.6.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "strip-ansi": "^6.0.1",
-        "wcwidth": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/npm/node_modules/common-ancestor-path": {
       "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/console-control-strings": {
-      "version": "1.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
@@ -4589,18 +4471,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT"
-    },
-    "node_modules/npm/node_modules/defaults": {
-      "version": "1.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "clone": "^1.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/npm/node_modules/diff": {
       "version": "5.2.0",
@@ -4700,42 +4570,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/npm/node_modules/gauge": {
-      "version": "5.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^1.0.3 || ^2.0.0",
-        "color-support": "^1.1.3",
-        "console-control-strings": "^1.1.0",
-        "has-unicode": "^2.0.1",
-        "signal-exit": "^4.0.1",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "wide-align": "^1.1.5"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
     "node_modules/npm/node_modules/glob": {
-      "version": "10.3.10",
+      "version": "10.4.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
-        "jackspeak": "^2.3.5",
-        "minimatch": "^9.0.1",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
-        "path-scurry": "^1.10.1"
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "path-scurry": "^1.11.1"
       },
       "bin": {
         "glob": "dist/esm/bin.mjs"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": ">=16 || 14 >=14.18"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -4747,14 +4598,8 @@
       "inBundle": true,
       "license": "ISC"
     },
-    "node_modules/npm/node_modules/has-unicode": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
     "node_modules/npm/node_modules/hasown": {
-      "version": "2.0.1",
+      "version": "2.0.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -4766,7 +4611,7 @@
       }
     },
     "node_modules/npm/node_modules/hosted-git-info": {
-      "version": "7.0.1",
+      "version": "7.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -4823,7 +4668,7 @@
       }
     },
     "node_modules/npm/node_modules/ignore-walk": {
-      "version": "6.0.4",
+      "version": "6.0.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -4853,7 +4698,7 @@
       }
     },
     "node_modules/npm/node_modules/ini": {
-      "version": "4.1.1",
+      "version": "4.1.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -4862,15 +4707,15 @@
       }
     },
     "node_modules/npm/node_modules/init-package-json": {
-      "version": "6.0.0",
+      "version": "6.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
+        "@npmcli/package-json": "^5.0.0",
         "npm-package-arg": "^11.0.0",
         "promzard": "^1.0.0",
-        "read": "^2.0.0",
-        "read-package-json": "^7.0.0",
+        "read": "^3.0.1",
         "semver": "^7.3.5",
         "validate-npm-package-license": "^3.0.4",
         "validate-npm-package-name": "^5.0.0"
@@ -4892,12 +4737,6 @@
         "node": ">= 12"
       }
     },
-    "node_modules/npm/node_modules/ip-address/node_modules/sprintf-js": {
-      "version": "1.1.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/npm/node_modules/ip-regex": {
       "version": "5.0.0",
       "dev": true,
@@ -4911,12 +4750,12 @@
       }
     },
     "node_modules/npm/node_modules/is-cidr": {
-      "version": "5.0.3",
+      "version": "5.1.0",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "cidr-regex": "4.0.3"
+        "cidr-regex": "^4.1.1"
       },
       "engines": {
         "node": ">=14"
@@ -4956,7 +4795,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/jackspeak": {
-      "version": "2.3.6",
+      "version": "3.1.2",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -4980,7 +4819,7 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/json-parse-even-better-errors": {
-      "version": "3.0.1",
+      "version": "3.0.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5019,52 +4858,50 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/libnpmaccess": {
-      "version": "8.0.2",
+      "version": "8.0.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-package-arg": "^11.0.1",
-        "npm-registry-fetch": "^16.0.0"
+        "npm-package-arg": "^11.0.2",
+        "npm-registry-fetch": "^17.0.1"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "6.0.7",
+      "version": "6.1.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^7.2.1",
-        "@npmcli/disparity-colors": "^3.0.0",
-        "@npmcli/installed-package-contents": "^2.0.2",
-        "binary-extensions": "^2.2.0",
+        "@npmcli/arborist": "^7.5.3",
+        "@npmcli/installed-package-contents": "^2.1.0",
+        "binary-extensions": "^2.3.0",
         "diff": "^5.1.0",
-        "minimatch": "^9.0.0",
-        "npm-package-arg": "^11.0.1",
-        "pacote": "^17.0.4",
-        "tar": "^6.2.0"
+        "minimatch": "^9.0.4",
+        "npm-package-arg": "^11.0.2",
+        "pacote": "^18.0.6",
+        "tar": "^6.2.1"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "7.0.8",
+      "version": "8.1.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^7.2.1",
-        "@npmcli/run-script": "^7.0.2",
+        "@npmcli/arborist": "^7.5.3",
+        "@npmcli/run-script": "^8.1.0",
         "ci-info": "^4.0.0",
-        "npm-package-arg": "^11.0.1",
-        "npmlog": "^7.0.1",
-        "pacote": "^17.0.4",
-        "proc-log": "^3.0.0",
-        "read": "^2.0.0",
+        "npm-package-arg": "^11.0.2",
+        "pacote": "^18.0.6",
+        "proc-log": "^4.2.0",
+        "read": "^3.0.1",
         "read-package-json-fast": "^3.0.2",
         "semver": "^7.3.7",
         "walk-up-path": "^3.0.1"
@@ -5074,112 +4911,112 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "5.0.5",
+      "version": "5.0.11",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^7.2.1"
+        "@npmcli/arborist": "^7.5.3"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmhook": {
-      "version": "10.0.1",
+      "version": "10.0.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "aproba": "^2.0.0",
-        "npm-registry-fetch": "^16.0.0"
+        "npm-registry-fetch": "^17.0.1"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmorg": {
-      "version": "6.0.2",
+      "version": "6.0.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "aproba": "^2.0.0",
-        "npm-registry-fetch": "^16.0.0"
+        "npm-registry-fetch": "^17.0.1"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "6.0.7",
+      "version": "7.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^7.2.1",
-        "@npmcli/run-script": "^7.0.2",
-        "npm-package-arg": "^11.0.1",
-        "pacote": "^17.0.4"
+        "@npmcli/arborist": "^7.5.3",
+        "@npmcli/run-script": "^8.1.0",
+        "npm-package-arg": "^11.0.2",
+        "pacote": "^18.0.6"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmpublish": {
-      "version": "9.0.4",
+      "version": "9.0.9",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "ci-info": "^4.0.0",
-        "normalize-package-data": "^6.0.0",
-        "npm-package-arg": "^11.0.1",
-        "npm-registry-fetch": "^16.0.0",
-        "proc-log": "^3.0.0",
+        "normalize-package-data": "^6.0.1",
+        "npm-package-arg": "^11.0.2",
+        "npm-registry-fetch": "^17.0.1",
+        "proc-log": "^4.2.0",
         "semver": "^7.3.7",
         "sigstore": "^2.2.0",
-        "ssri": "^10.0.5"
+        "ssri": "^10.0.6"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmsearch": {
-      "version": "7.0.1",
+      "version": "7.0.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-registry-fetch": "^16.0.0"
+        "npm-registry-fetch": "^17.0.1"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmteam": {
-      "version": "6.0.1",
+      "version": "6.0.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "aproba": "^2.0.0",
-        "npm-registry-fetch": "^16.0.0"
+        "npm-registry-fetch": "^17.0.1"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmversion": {
-      "version": "5.0.2",
+      "version": "6.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/git": "^5.0.3",
-        "@npmcli/run-script": "^7.0.2",
-        "json-parse-even-better-errors": "^3.0.0",
-        "proc-log": "^3.0.0",
+        "@npmcli/git": "^5.0.7",
+        "@npmcli/run-script": "^8.1.0",
+        "json-parse-even-better-errors": "^3.0.2",
+        "proc-log": "^4.2.0",
         "semver": "^7.3.7"
       },
       "engines": {
@@ -5187,7 +5024,7 @@
       }
     },
     "node_modules/npm/node_modules/lru-cache": {
-      "version": "10.2.0",
+      "version": "10.2.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -5196,7 +5033,7 @@
       }
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
-      "version": "13.0.0",
+      "version": "13.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -5210,6 +5047,7 @@
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
         "negotiator": "^0.6.3",
+        "proc-log": "^4.2.0",
         "promise-retry": "^2.0.1",
         "ssri": "^10.0.0"
       },
@@ -5218,7 +5056,7 @@
       }
     },
     "node_modules/npm/node_modules/minimatch": {
-      "version": "9.0.3",
+      "version": "9.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -5233,7 +5071,7 @@
       }
     },
     "node_modules/npm/node_modules/minipass": {
-      "version": "7.0.4",
+      "version": "7.1.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -5254,7 +5092,7 @@
       }
     },
     "node_modules/npm/node_modules/minipass-fetch": {
-      "version": "3.0.4",
+      "version": "3.0.5",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5426,7 +5264,7 @@
       }
     },
     "node_modules/npm/node_modules/node-gyp": {
-      "version": "10.0.1",
+      "version": "10.1.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5449,8 +5287,17 @@
         "node": "^16.14.0 || >=18.0.0"
       }
     },
+    "node_modules/npm/node_modules/node-gyp/node_modules/proc-log": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/npm/node_modules/nopt": {
-      "version": "7.2.0",
+      "version": "7.2.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -5465,7 +5312,7 @@
       }
     },
     "node_modules/npm/node_modules/normalize-package-data": {
-      "version": "6.0.0",
+      "version": "6.0.1",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -5489,7 +5336,7 @@
       }
     },
     "node_modules/npm/node_modules/npm-bundled": {
-      "version": "3.0.0",
+      "version": "3.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -5522,13 +5369,13 @@
       }
     },
     "node_modules/npm/node_modules/npm-package-arg": {
-      "version": "11.0.1",
+      "version": "11.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "hosted-git-info": "^7.0.0",
-        "proc-log": "^3.0.0",
+        "proc-log": "^4.0.0",
         "semver": "^7.3.5",
         "validate-npm-package-name": "^5.0.0"
       },
@@ -5549,7 +5396,7 @@
       }
     },
     "node_modules/npm/node_modules/npm-pick-manifest": {
-      "version": "9.0.0",
+      "version": "9.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -5564,56 +5411,42 @@
       }
     },
     "node_modules/npm/node_modules/npm-profile": {
-      "version": "9.0.0",
+      "version": "10.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-registry-fetch": "^16.0.0",
-        "proc-log": "^3.0.0"
+        "npm-registry-fetch": "^17.0.1",
+        "proc-log": "^4.0.0"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/npm/node_modules/npm-registry-fetch": {
-      "version": "16.1.0",
+      "version": "17.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
+        "@npmcli/redact": "^2.0.0",
         "make-fetch-happen": "^13.0.0",
         "minipass": "^7.0.2",
         "minipass-fetch": "^3.0.0",
         "minipass-json-stream": "^1.0.1",
         "minizlib": "^2.1.2",
         "npm-package-arg": "^11.0.0",
-        "proc-log": "^3.0.0"
+        "proc-log": "^4.0.0"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/npm-user-validate": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/npmlog": {
-      "version": "7.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "are-we-there-yet": "^4.0.0",
-        "console-control-strings": "^1.1.0",
-        "gauge": "^5.0.0",
-        "set-blocking": "^2.0.0"
-      },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
@@ -5634,32 +5467,31 @@
       }
     },
     "node_modules/npm/node_modules/pacote": {
-      "version": "17.0.6",
+      "version": "18.0.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/git": "^5.0.0",
         "@npmcli/installed-package-contents": "^2.0.1",
+        "@npmcli/package-json": "^5.1.0",
         "@npmcli/promise-spawn": "^7.0.0",
-        "@npmcli/run-script": "^7.0.0",
+        "@npmcli/run-script": "^8.0.0",
         "cacache": "^18.0.0",
         "fs-minipass": "^3.0.0",
         "minipass": "^7.0.2",
         "npm-package-arg": "^11.0.0",
         "npm-packlist": "^8.0.0",
         "npm-pick-manifest": "^9.0.0",
-        "npm-registry-fetch": "^16.0.0",
-        "proc-log": "^3.0.0",
+        "npm-registry-fetch": "^17.0.0",
+        "proc-log": "^4.0.0",
         "promise-retry": "^2.0.1",
-        "read-package-json": "^7.0.0",
-        "read-package-json-fast": "^3.0.0",
         "sigstore": "^2.2.0",
         "ssri": "^10.0.0",
         "tar": "^6.1.11"
       },
       "bin": {
-        "pacote": "lib/bin.js"
+        "pacote": "bin/index.js"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
@@ -5689,23 +5521,23 @@
       }
     },
     "node_modules/npm/node_modules/path-scurry": {
-      "version": "1.10.1",
+      "version": "1.11.1",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "lru-cache": "^9.1.1 || ^10.0.0",
+        "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": ">=16 || 14 >=14.18"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/npm/node_modules/postcss-selector-parser": {
-      "version": "6.0.15",
+      "version": "6.1.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5718,7 +5550,16 @@
       }
     },
     "node_modules/npm/node_modules/proc-log": {
-      "version": "3.0.0",
+      "version": "4.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/proggy": {
+      "version": "2.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -5764,12 +5605,12 @@
       }
     },
     "node_modules/npm/node_modules/promzard": {
-      "version": "1.0.0",
+      "version": "1.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "read": "^2.0.0"
+        "read": "^3.0.1"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -5784,12 +5625,12 @@
       }
     },
     "node_modules/npm/node_modules/read": {
-      "version": "2.1.0",
+      "version": "3.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "mute-stream": "~1.0.0"
+        "mute-stream": "^1.0.0"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -5802,21 +5643,6 @@
       "license": "ISC",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/read-package-json": {
-      "version": "7.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^10.2.2",
-        "json-parse-even-better-errors": "^3.0.0",
-        "normalize-package-data": "^6.0.0",
-        "npm-normalize-package-bin": "^3.0.0"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/read-package-json-fast": {
@@ -5849,37 +5675,16 @@
       "optional": true
     },
     "node_modules/npm/node_modules/semver": {
-      "version": "7.6.0",
+      "version": "7.6.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/npm/node_modules/semver/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/set-blocking": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
     },
     "node_modules/npm/node_modules/shebang-command": {
       "version": "2.0.0",
@@ -5915,17 +5720,17 @@
       }
     },
     "node_modules/npm/node_modules/sigstore": {
-      "version": "2.2.2",
+      "version": "2.3.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@sigstore/bundle": "^2.2.0",
+        "@sigstore/bundle": "^2.3.2",
         "@sigstore/core": "^1.0.0",
-        "@sigstore/protobuf-specs": "^0.3.0",
-        "@sigstore/sign": "^2.2.3",
-        "@sigstore/tuf": "^2.3.1",
-        "@sigstore/verify": "^1.1.0"
+        "@sigstore/protobuf-specs": "^0.3.2",
+        "@sigstore/sign": "^2.3.2",
+        "@sigstore/tuf": "^2.3.4",
+        "@sigstore/verify": "^1.2.1"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
@@ -5942,7 +5747,7 @@
       }
     },
     "node_modules/npm/node_modules/socks": {
-      "version": "2.8.0",
+      "version": "2.8.3",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5951,17 +5756,17 @@
         "smart-buffer": "^4.2.0"
       },
       "engines": {
-        "node": ">= 16.0.0",
+        "node": ">= 10.0.0",
         "npm": ">= 3.0.0"
       }
     },
     "node_modules/npm/node_modules/socks-proxy-agent": {
-      "version": "8.0.2",
+      "version": "8.0.3",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "agent-base": "^7.0.2",
+        "agent-base": "^7.1.1",
         "debug": "^4.3.4",
         "socks": "^2.7.1"
       },
@@ -5979,13 +5784,7 @@
         "spdx-license-ids": "^3.0.0"
       }
     },
-    "node_modules/npm/node_modules/spdx-exceptions": {
-      "version": "2.5.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "CC-BY-3.0"
-    },
-    "node_modules/npm/node_modules/spdx-expression-parse": {
+    "node_modules/npm/node_modules/spdx-correct/node_modules/spdx-expression-parse": {
       "version": "3.0.1",
       "dev": true,
       "inBundle": true,
@@ -5995,14 +5794,36 @@
         "spdx-license-ids": "^3.0.0"
       }
     },
+    "node_modules/npm/node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/npm/node_modules/spdx-expression-parse": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
     "node_modules/npm/node_modules/spdx-license-ids": {
-      "version": "3.0.17",
+      "version": "3.0.18",
       "dev": true,
       "inBundle": true,
       "license": "CC0-1.0"
     },
+    "node_modules/npm/node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/npm/node_modules/ssri": {
-      "version": "10.0.5",
+      "version": "10.0.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -6080,7 +5901,7 @@
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "6.2.0",
+      "version": "6.2.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -6151,14 +5972,14 @@
       }
     },
     "node_modules/npm/node_modules/tuf-js": {
-      "version": "2.2.0",
+      "version": "2.2.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "@tufjs/models": "2.0.0",
+        "@tufjs/models": "2.0.1",
         "debug": "^4.3.4",
-        "make-fetch-happen": "^13.0.0"
+        "make-fetch-happen": "^13.0.1"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
@@ -6204,14 +6025,21 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "node_modules/npm/node_modules/validate-npm-package-license/node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
     "node_modules/npm/node_modules/validate-npm-package-name": {
-      "version": "5.0.0",
+      "version": "5.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "dependencies": {
-        "builtins": "^5.0.0"
-      },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
@@ -6221,15 +6049,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC"
-    },
-    "node_modules/npm/node_modules/wcwidth": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "defaults": "^1.0.3"
-      }
     },
     "node_modules/npm/node_modules/which": {
       "version": "4.0.0",
@@ -6253,15 +6072,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=16"
-      }
-    },
-    "node_modules/npm/node_modules/wide-align": {
-      "version": "1.1.5",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
     "node_modules/npm/node_modules/wrap-ansi": {
@@ -6495,11 +6305,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/packet-reader": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
-      "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -6525,6 +6330,18 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6588,15 +6405,13 @@
       }
     },
     "node_modules/pg": {
-      "version": "8.11.3",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.11.3.tgz",
-      "integrity": "sha512-+9iuvG8QfaaUrrph+kpF24cXkH1YOOUeArRNYIxq1viYHZagBxrTno7cecY1Fa44tJeZvaoG+Djpkc3JwehN5g==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.12.0.tgz",
+      "integrity": "sha512-A+LHUSnwnxrnL/tZ+OLfqR1SxLN3c/pgDztZ47Rpbsd4jUytsTtwQo/TLPRzPJMp/1pbhYVhH9cuSZLAajNfjQ==",
       "dependencies": {
-        "buffer-writer": "2.0.0",
-        "packet-reader": "1.0.0",
-        "pg-connection-string": "^2.6.2",
-        "pg-pool": "^3.6.1",
-        "pg-protocol": "^1.6.0",
+        "pg-connection-string": "^2.6.4",
+        "pg-pool": "^3.6.2",
+        "pg-protocol": "^1.6.1",
         "pg-types": "^2.1.0",
         "pgpass": "1.x"
       },
@@ -6622,9 +6437,9 @@
       "optional": true
     },
     "node_modules/pg-connection-string": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.2.tgz",
-      "integrity": "sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA=="
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.4.tgz",
+      "integrity": "sha512-v+Z7W/0EO707aNMaAEfiGnGL9sxxumwLl2fJvCQtMn9Fxsg+lPpPkdcyBSv/KFgpGdYkMfn+EI1Or2EHjpgLCA=="
     },
     "node_modules/pg-int8": {
       "version": "1.0.1",
@@ -6643,17 +6458,17 @@
       }
     },
     "node_modules/pg-pool": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.6.1.tgz",
-      "integrity": "sha512-jizsIzhkIitxCGfPRzJn1ZdcosIt3pz9Sh3V01fm1vZnbnCMgmGl5wvGGdNN2EL9Rmb0EcFoCkixH4Pu+sP9Og==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.6.2.tgz",
+      "integrity": "sha512-Htjbg8BlwXqSBQ9V8Vjtc+vzf/6fVUuak/3/XXKA9oxZprwW3IMDQTGHP+KDmVL7rtd+R1QjbnCFPuTHm3G4hg==",
       "peerDependencies": {
         "pg": ">=8.0"
       }
     },
     "node_modules/pg-protocol": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.0.tgz",
-      "integrity": "sha512-M+PDm637OY5WM307051+bsDia5Xej6d9IR4GwJse1qA1DIhiKlksvrneZOYQq42OM+spubpcNYEo2FcKQrDk+Q=="
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.1.tgz",
+      "integrity": "sha512-jPIlvgoD63hrEuihvIg+tJhoGjUsLPn6poJY9N5CnlPd91c2T18T/9zBtLxZSb1EhYxBRoZJtzScCaWlYLtktg=="
     },
     "node_modules/pg-types": {
       "version": "2.2.0",
@@ -6828,6 +6643,21 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-ms": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.0.0.tgz",
+      "integrity": "sha512-E9e9HJ9R9NasGOgPaPE8VMeiPKAyWR5jcFpNnwIejslIhWqdqOrb2wShBsncMPUb+BcCd2OPYfh7p2W6oemTng==",
+      "dev": true,
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -6884,6 +6714,35 @@
         "rc": "cli.js"
       }
     },
+    "node_modules/read-package-up": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-11.0.0.tgz",
+      "integrity": "sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==",
+      "dev": true,
+      "dependencies": {
+        "find-up-simple": "^1.0.0",
+        "read-pkg": "^9.0.0",
+        "type-fest": "^4.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-package-up/node_modules/type-fest": {
+      "version": "4.20.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.20.1.tgz",
+      "integrity": "sha512-R6wDsVsoS9xYOpy8vgeBlqpdOyzJ12HNfQhC/aAKWM3YoCV9TtunJzh/QpkMgeDhkoynDcw5f1y+qF9yc/HHyg==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/read-pkg": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
@@ -6898,36 +6757,6 @@
       },
       "engines": {
         "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/read-pkg-up": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-11.0.0.tgz",
-      "integrity": "sha512-LOVbvF1Q0SZdjClSefZ0Nz5z8u+tIE7mV5NibzmE9VYmDe9CaBbAVtz1veOSZbofrdsilxuDAYnFenukZVp8/Q==",
-      "deprecated": "Renamed to read-package-up",
-      "dev": true,
-      "dependencies": {
-        "find-up-simple": "^1.0.0",
-        "read-pkg": "^9.0.0",
-        "type-fest": "^4.6.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/type-fest": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.12.0.tgz",
-      "integrity": "sha512-5Y2/pp2wtJk8o08G0CMkuFPCO354FGwk/vbidxrdhRGZfd0tFnb4Qb8anp9XxXriwBgVPjdWbKpGl4J9lJY2jQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -7021,6 +6850,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "dependencies": {
         "glob": "^7.1.3"
@@ -7067,23 +6897,23 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/semantic-release": {
-      "version": "23.0.5",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-23.0.5.tgz",
-      "integrity": "sha512-4eZG/vRTV8E7rw5oHPv2Fht5qx6ITemE/b1vzG42ayYVcffJqXYy40nP4bHEPWX1/kleJWWrlPVDt1hSYVlpKQ==",
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-24.0.0.tgz",
+      "integrity": "sha512-v46CRPw+9eI3ZuYGF2oAjqPqsfbnfFTwLBgQsv/lch4goD09ytwOTESMN4QIrx/wPLxUGey60/NMx+ANQtWRsA==",
       "dev": true,
       "dependencies": {
-        "@semantic-release/commit-analyzer": "^12.0.0",
+        "@semantic-release/commit-analyzer": "^13.0.0-beta.1",
         "@semantic-release/error": "^4.0.0",
         "@semantic-release/github": "^10.0.0",
         "@semantic-release/npm": "^12.0.0",
-        "@semantic-release/release-notes-generator": "^12.0.0",
+        "@semantic-release/release-notes-generator": "^14.0.0-beta.1",
         "aggregate-error": "^5.0.0",
         "cosmiconfig": "^9.0.0",
         "debug": "^4.0.0",
         "env-ci": "^11.0.0",
-        "execa": "^8.0.0",
+        "execa": "^9.0.0",
         "figures": "^6.0.0",
-        "find-versions": "^5.1.0",
+        "find-versions": "^6.0.0",
         "get-stream": "^6.0.0",
         "git-log-parser": "^1.2.0",
         "hook-std": "^3.0.0",
@@ -7095,7 +6925,7 @@
         "micromatch": "^4.0.2",
         "p-each-series": "^3.0.0",
         "p-reduce": "^3.0.0",
-        "read-pkg-up": "^11.0.0",
+        "read-package-up": "^11.0.0",
         "resolve-from": "^5.0.0",
         "semver": "^7.3.2",
         "semver-diff": "^4.0.0",
@@ -7116,6 +6946,18 @@
       "dev": true,
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/semantic-release/node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/semantic-release/node_modules/aggregate-error": {
@@ -7162,47 +7004,54 @@
       }
     },
     "node_modules/semantic-release/node_modules/execa": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
-      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.2.0.tgz",
+      "integrity": "sha512-vpOyYg7UAVKLAWWtRS2gAdgkT7oJbCn0me3gmUmxZih4kd3MF/oo8kNTBTIbkO3yuuF5uB4ZCZfn8BOolITYhg==",
       "dev": true,
       "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
         "cross-spawn": "^7.0.3",
-        "get-stream": "^8.0.1",
-        "human-signals": "^5.0.0",
-        "is-stream": "^3.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^5.1.0",
-        "onetime": "^6.0.0",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^7.0.0",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^5.2.0",
+        "pretty-ms": "^9.0.0",
         "signal-exit": "^4.1.0",
-        "strip-final-newline": "^3.0.0"
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.0.0"
       },
       "engines": {
-        "node": ">=16.17"
+        "node": "^18.19.0 || >=20.5.0"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
     "node_modules/semantic-release/node_modules/execa/node_modules/get-stream": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
-      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
       "dev": true,
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/semantic-release/node_modules/human-signals": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
-      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-7.0.0.tgz",
+      "integrity": "sha512-74kytxOUSvNbjrT9KisAbaTZ/eJwD/LrbM/kh5j0IhPuJzwuA19dWvniFGwBzN9rVjg+O/e+F310PjObDXS+9Q==",
       "dev": true,
       "engines": {
-        "node": ">=16.17.0"
+        "node": ">=18.18.0"
       }
     },
     "node_modules/semantic-release/node_modules/indent-string": {
@@ -7218,12 +7067,12 @@
       }
     },
     "node_modules/semantic-release/node_modules/is-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
       "dev": true,
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -7241,43 +7090,16 @@
         "node": ">= 18"
       }
     },
-    "node_modules/semantic-release/node_modules/mimic-fn": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/semantic-release/node_modules/npm-run-path": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
-      "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
       "dev": true,
       "dependencies": {
         "path-key": "^4.0.0"
       },
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/semantic-release/node_modules/onetime": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-      "dev": true,
-      "dependencies": {
-        "mimic-fn": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -7320,25 +7142,22 @@
       }
     },
     "node_modules/semantic-release/node_modules/strip-final-newline": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
       "dev": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -7587,6 +7406,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/super-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/super-regex/-/super-regex-1.0.0.tgz",
+      "integrity": "sha512-CY8u7DtbvucKuquCmOFEKhr9Besln7n9uN8eFbwcoGYWXOMW07u2o8njWaiXt11ylS3qoGF55pILjRmPlbodyg==",
+      "dev": true,
+      "dependencies": {
+        "function-timeout": "^1.0.1",
+        "time-span": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -7684,18 +7519,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/text-extensions": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-2.4.0.tgz",
-      "integrity": "sha512-te/NtwBwfiNRLf9Ijqx3T0nlqZiQ2XrrtBvu+cLL8ZRrGkO0NHTug8MYFKyoSrv/sHTaSKfilUkizV6XhxMJ3g==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -7723,11 +7546,20 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
-      "dev": true
+    "node_modules/time-span": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/time-span/-/time-span-5.1.0.tgz",
+      "integrity": "sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==",
+      "dev": true,
+      "dependencies": {
+        "convert-hrtime": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -7787,9 +7619,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
+      "integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -7800,9 +7632,9 @@
       }
     },
     "node_modules/uglify-js": {
-      "version": "3.17.4",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
-      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.18.0.tgz",
+      "integrity": "sha512-SyVVbcNBCk0dzr9XL/R/ySrmYf0s372K6/hFklzgcp2lBFyXtw4I7BOdDjlLhE1aVqaI/SHWXWmYdlZxuyF38A==",
       "dev": true,
       "optional": true,
       "bin": {
@@ -7996,12 +7828,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
-    },
     "node_modules/yargs": {
       "version": "17.6.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
@@ -8036,6 +7862,18 @@
       "dev": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.0.2.tgz",
+      "integrity": "sha512-Ct97huExsu7cWeEjmrXlofevF8CvzUglJ4iGUet5B8xn1oumtAZBpHU4GzYuoE6PVqcZ5hghtBrSlhwHuR1Jmw==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   },
@@ -8090,9 +7928,9 @@
       }
     },
     "@eslint-community/regexpp": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.6.2.tgz",
-      "integrity": "sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.1.tgz",
+      "integrity": "sha512-Zm2NGpWELsQAD1xsJzGQpYfvICSsFkEpU0jxBjfdC6uNEWXcHnfs9hScFWtXVDVl+rBQJGrl4g1vcKIejpH9dA==",
       "dev": true
     },
     "@eslint/eslintrc": {
@@ -8144,9 +7982,9 @@
       "dev": true
     },
     "@humanwhocodes/object-schema": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz",
-      "integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
       "dev": true
     },
     "@js-ak/mysql-migration-system": {
@@ -8234,12 +8072,29 @@
       "dev": true
     },
     "@octokit/plugin-paginate-rest": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-10.0.0.tgz",
-      "integrity": "sha512-G1Z67qOiFneKDJyMafHQkWnKm1kU3FfbRZLzxgsFg4dOa3pRNdABbdk+xo/oev6P88lnbt7GKdBNB6dJZuPphA==",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.3.0.tgz",
+      "integrity": "sha512-n4znWfRinnUQF6TPyxs7EctSAA3yVSP4qlJP2YgI3g9d4Ae2n5F3XDOjbUluKRxPU3rfsgpOboI4O4VtPc6Ilg==",
       "dev": true,
       "requires": {
-        "@octokit/types": "^12.6.0"
+        "@octokit/types": "^13.5.0"
+      },
+      "dependencies": {
+        "@octokit/openapi-types": {
+          "version": "22.2.0",
+          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.2.0.tgz",
+          "integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==",
+          "dev": true
+        },
+        "@octokit/types": {
+          "version": "13.5.0",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.5.0.tgz",
+          "integrity": "sha512-HdqWTf5Z3qwDVlzCrP8UJquMwunpDiMPt5er+QjGzL4hqr/vBVY/MauQgS1xWxCDT1oMx1EULyqxncdCY/NVSQ==",
+          "dev": true,
+          "requires": {
+            "@octokit/openapi-types": "^22.2.0"
+          }
+        }
       }
     },
     "@octokit/plugin-retry": {
@@ -8312,6 +8167,12 @@
         "config-chain": "^1.1.11"
       }
     },
+    "@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "dev": true
+    },
     "@semantic-release/changelog": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-6.0.3.tgz",
@@ -8325,14 +8186,15 @@
       }
     },
     "@semantic-release/commit-analyzer": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-12.0.0.tgz",
-      "integrity": "sha512-qG+md5gdes+xa8zP7lIo1fWE17zRdO8yMCaxh9lyL65TQleoSv8WHHOqRURfghTytUh+NpkSyBprQ5hrkxOKVQ==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-13.0.0.tgz",
+      "integrity": "sha512-KtXWczvTAB1ZFZ6B4O+w8HkfYm/OgQb1dUGNFZtDgQ0csggrmkq8sTxhd+lwGF8kMb59/RnG9o4Tn7M/I8dQ9Q==",
       "dev": true,
       "requires": {
-        "conventional-changelog-angular": "^7.0.0",
-        "conventional-commits-filter": "^4.0.0",
-        "conventional-commits-parser": "^5.0.0",
+        "conventional-changelog-angular": "^8.0.0",
+        "conventional-changelog-writer": "^8.0.0",
+        "conventional-commits-filter": "^5.0.0",
+        "conventional-commits-parser": "^6.0.0",
         "debug": "^4.0.0",
         "import-from-esm": "^1.0.3",
         "lodash-es": "^4.17.21",
@@ -8362,13 +8224,13 @@
       }
     },
     "@semantic-release/github": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-10.0.2.tgz",
-      "integrity": "sha512-SP5ihhv/uQa8vPuWKmbJrrzfv8lRUkDFC6qwgaWoorrflN1DEW0IGCa9w/PxUp8Ad3dbvXZPmpXdGiP3eyTzhg==",
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-10.0.6.tgz",
+      "integrity": "sha512-sS4psqZacGTFEN49UQGqwFNG6Jyx2/RX1BhhDGn/2WoPbhAHislohOY05/5r+JoL4gJMWycfH7tEm1eGVutYeg==",
       "dev": true,
       "requires": {
         "@octokit/core": "^6.0.0",
-        "@octokit/plugin-paginate-rest": "^10.0.0",
+        "@octokit/plugin-paginate-rest": "^11.0.0",
         "@octokit/plugin-retry": "^7.0.0",
         "@octokit/plugin-throttling": "^9.0.0",
         "@semantic-release/error": "^4.0.0",
@@ -8451,14 +8313,14 @@
       }
     },
     "@semantic-release/npm": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-12.0.0.tgz",
-      "integrity": "sha512-72TVYQCH9NvVsO/y13eF8vE4bNnfls518+4KcFwJUKi7AtA/ZXoNgSg9gTTfw5eMZMkiH0izUrpGXgZE/cSQhA==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-12.0.1.tgz",
+      "integrity": "sha512-/6nntGSUGK2aTOI0rHPwY3ZjgY9FkXmEHbW9Kr+62NVOsyqpKKeP0lrCH+tphv+EsNdJNmqqwijTEnVWUMQ2Nw==",
       "dev": true,
       "requires": {
         "@semantic-release/error": "^4.0.0",
         "aggregate-error": "^5.0.0",
-        "execa": "^8.0.0",
+        "execa": "^9.0.0",
         "fs-extra": "^11.0.0",
         "lodash-es": "^4.17.21",
         "nerf-dart": "^1.0.0",
@@ -8475,6 +8337,12 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
           "integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
+          "dev": true
+        },
+        "@sindresorhus/merge-streams": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+          "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
           "dev": true
         },
         "aggregate-error": {
@@ -8503,32 +8371,39 @@
           "dev": true
         },
         "execa": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
-          "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+          "version": "9.2.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-9.2.0.tgz",
+          "integrity": "sha512-vpOyYg7UAVKLAWWtRS2gAdgkT7oJbCn0me3gmUmxZih4kd3MF/oo8kNTBTIbkO3yuuF5uB4ZCZfn8BOolITYhg==",
           "dev": true,
           "requires": {
+            "@sindresorhus/merge-streams": "^4.0.0",
             "cross-spawn": "^7.0.3",
-            "get-stream": "^8.0.1",
-            "human-signals": "^5.0.0",
-            "is-stream": "^3.0.0",
-            "merge-stream": "^2.0.0",
-            "npm-run-path": "^5.1.0",
-            "onetime": "^6.0.0",
+            "figures": "^6.1.0",
+            "get-stream": "^9.0.0",
+            "human-signals": "^7.0.0",
+            "is-plain-obj": "^4.1.0",
+            "is-stream": "^4.0.1",
+            "npm-run-path": "^5.2.0",
+            "pretty-ms": "^9.0.0",
             "signal-exit": "^4.1.0",
-            "strip-final-newline": "^3.0.0"
+            "strip-final-newline": "^4.0.0",
+            "yoctocolors": "^2.0.0"
           }
         },
         "get-stream": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
-          "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
-          "dev": true
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+          "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+          "dev": true,
+          "requires": {
+            "@sec-ant/readable-stream": "^0.4.1",
+            "is-stream": "^4.0.1"
+          }
         },
         "human-signals": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
-          "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-7.0.0.tgz",
+          "integrity": "sha512-74kytxOUSvNbjrT9KisAbaTZ/eJwD/LrbM/kh5j0IhPuJzwuA19dWvniFGwBzN9rVjg+O/e+F310PjObDXS+9Q==",
           "dev": true
         },
         "indent-string": {
@@ -8538,33 +8413,18 @@
           "dev": true
         },
         "is-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-          "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-          "dev": true
-        },
-        "mimic-fn": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-          "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+          "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
           "dev": true
         },
         "npm-run-path": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
-          "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+          "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
           "dev": true,
           "requires": {
             "path-key": "^4.0.0"
-          }
-        },
-        "onetime": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-          "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-          "dev": true,
-          "requires": {
-            "mimic-fn": "^4.0.0"
           }
         },
         "path-key": {
@@ -8580,29 +8440,29 @@
           "dev": true
         },
         "strip-final-newline": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-          "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+          "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
           "dev": true
         }
       }
     },
     "@semantic-release/release-notes-generator": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-12.1.0.tgz",
-      "integrity": "sha512-g6M9AjUKAZUZnxaJZnouNBeDNTCUrJ5Ltj+VJ60gJeDaRRahcHsry9HW8yKrnKkKNkx5lbWiEP1FPMqVNQz8Kg==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-14.0.1.tgz",
+      "integrity": "sha512-K0w+5220TM4HZTthE5dDpIuFrnkN1NfTGPidJFm04ULT1DEZ9WG89VNXN7F0c+6nMEpWgqmPvb7vY7JkB2jyyA==",
       "dev": true,
       "requires": {
-        "conventional-changelog-angular": "^7.0.0",
-        "conventional-changelog-writer": "^7.0.0",
-        "conventional-commits-filter": "^4.0.0",
-        "conventional-commits-parser": "^5.0.0",
+        "conventional-changelog-angular": "^8.0.0",
+        "conventional-changelog-writer": "^8.0.0",
+        "conventional-commits-filter": "^5.0.0",
+        "conventional-commits-parser": "^6.0.0",
         "debug": "^4.0.0",
         "get-stream": "^7.0.0",
         "import-from-esm": "^1.0.3",
         "into-stream": "^7.0.0",
         "lodash-es": "^4.17.21",
-        "read-pkg-up": "^11.0.0"
+        "read-package-up": "^11.0.0"
       },
       "dependencies": {
         "get-stream": {
@@ -8625,16 +8485,10 @@
       "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
       "dev": true
     },
-    "@types/json-schema": {
-      "version": "7.0.15",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true
-    },
     "@types/node": {
-      "version": "20.11.30",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.30.tgz",
-      "integrity": "sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==",
+      "version": "20.14.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.8.tgz",
+      "integrity": "sha512-DO+2/jZinXfROG7j7WKFn/3C6nFwxy2lLpgLjEXJz+0XKphZlTLJ14mo8Vfg8X5BWN6XjyESXq+LcYdT7tR3bA==",
       "requires": {
         "undici-types": "~5.26.4"
       }
@@ -8646,9 +8500,9 @@
       "dev": true
     },
     "@types/pg": {
-      "version": "8.11.2",
-      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.11.2.tgz",
-      "integrity": "sha512-G2Mjygf2jFMU/9hCaTYxJrwdObdcnuQde1gndooZSOHsNSaCehAuwc7EIuSA34Do8Jx2yZ19KtvW8P0j4EuUXw==",
+      "version": "8.11.6",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.11.6.tgz",
+      "integrity": "sha512-/2WmmBXHLsfRqzfHW7BNZ8SbYzE8OSk7i3WjFYvfgRHj7S1xj+16Je5fUKv3lVdVzk/zn9TXOqf+avFCFIE0yQ==",
       "requires": {
         "@types/node": "*",
         "pg-protocol": "*",
@@ -8701,79 +8555,91 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.3.1.tgz",
-      "integrity": "sha512-STEDMVQGww5lhCuNXVSQfbfuNII5E08QWkvAw5Qwf+bj2WT+JkG1uc+5/vXA3AOYMDHVOSpL+9rcbEUiHIm2dw==",
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.13.1.tgz",
+      "integrity": "sha512-kZqi+WZQaZfPKnsflLJQCz6Ze9FFSMfXrrIOcyargekQxG37ES7DJNpJUE9Q/X5n3yTIP/WPutVNzgknQ7biLg==",
       "dev": true,
       "requires": {
-        "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "7.3.1",
-        "@typescript-eslint/type-utils": "7.3.1",
-        "@typescript-eslint/utils": "7.3.1",
-        "@typescript-eslint/visitor-keys": "7.3.1",
-        "debug": "^4.3.4",
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "7.13.1",
+        "@typescript-eslint/type-utils": "7.13.1",
+        "@typescript-eslint/utils": "7.13.1",
+        "@typescript-eslint/visitor-keys": "7.13.1",
         "graphemer": "^1.4.0",
-        "ignore": "^5.2.4",
+        "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
+        "ts-api-utils": "^1.3.0"
+      },
+      "dependencies": {
+        "@typescript-eslint/type-utils": {
+          "version": "7.13.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.13.1.tgz",
+          "integrity": "sha512-aWDbLu1s9bmgPGXSzNCxELu+0+HQOapV/y+60gPXafR8e2g1Bifxzevaa+4L2ytCWm+CHqpELq4CSoN9ELiwCg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/typescript-estree": "7.13.1",
+            "@typescript-eslint/utils": "7.13.1",
+            "debug": "^4.3.4",
+            "ts-api-utils": "^1.3.0"
+          }
+        },
+        "@typescript-eslint/utils": {
+          "version": "7.13.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.13.1.tgz",
+          "integrity": "sha512-h5MzFBD5a/Gh/fvNdp9pTfqJAbuQC4sCN2WzuXme71lqFJsZtLbjxfSk4r3p02WIArOF9N94pdsLiGutpDbrXQ==",
+          "dev": true,
+          "requires": {
+            "@eslint-community/eslint-utils": "^4.4.0",
+            "@typescript-eslint/scope-manager": "7.13.1",
+            "@typescript-eslint/types": "7.13.1",
+            "@typescript-eslint/typescript-estree": "7.13.1"
+          }
+        }
       }
     },
     "@typescript-eslint/parser": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.3.1.tgz",
-      "integrity": "sha512-Rq49+pq7viTRCH48XAbTA+wdLRrB/3sRq4Lpk0oGDm0VmnjBrAOVXH/Laalmwsv2VpekiEfVFwJYVk6/e8uvQw==",
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.13.1.tgz",
+      "integrity": "sha512-1ELDPlnLvDQ5ybTSrMhRTFDfOQEOXNM+eP+3HT/Yq7ruWpciQw+Avi73pdEbA4SooCawEWo3dtYbF68gN7Ed1A==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "7.3.1",
-        "@typescript-eslint/types": "7.3.1",
-        "@typescript-eslint/typescript-estree": "7.3.1",
-        "@typescript-eslint/visitor-keys": "7.3.1",
+        "@typescript-eslint/scope-manager": "7.13.1",
+        "@typescript-eslint/types": "7.13.1",
+        "@typescript-eslint/typescript-estree": "7.13.1",
+        "@typescript-eslint/visitor-keys": "7.13.1",
         "debug": "^4.3.4"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.3.1.tgz",
-      "integrity": "sha512-fVS6fPxldsKY2nFvyT7IP78UO1/I2huG+AYu5AMjCT9wtl6JFiDnsv4uad4jQ0GTFzcUV5HShVeN96/17bTBag==",
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.13.1.tgz",
+      "integrity": "sha512-adbXNVEs6GmbzaCpymHQ0MB6E4TqoiVbC0iqG3uijR8ZYfpAXMGttouQzF4Oat3P2GxDVIrg7bMI/P65LiQZdg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "7.3.1",
-        "@typescript-eslint/visitor-keys": "7.3.1"
-      }
-    },
-    "@typescript-eslint/type-utils": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.3.1.tgz",
-      "integrity": "sha512-iFhaysxFsMDQlzJn+vr3OrxN8NmdQkHks4WaqD4QBnt5hsq234wcYdyQ9uquzJJIDAj5W4wQne3yEsYA6OmXGw==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/typescript-estree": "7.3.1",
-        "@typescript-eslint/utils": "7.3.1",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^1.0.1"
+        "@typescript-eslint/types": "7.13.1",
+        "@typescript-eslint/visitor-keys": "7.13.1"
       }
     },
     "@typescript-eslint/types": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.3.1.tgz",
-      "integrity": "sha512-2tUf3uWggBDl4S4183nivWQ2HqceOZh1U4hhu4p1tPiIJoRRXrab7Y+Y0p+dozYwZVvLPRI6r5wKe9kToF9FIw==",
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.13.1.tgz",
+      "integrity": "sha512-7K7HMcSQIAND6RBL4kDl24sG/xKM13cA85dc7JnmQXw2cBDngg7c19B++JzvJHRG3zG36n9j1i451GBzRuHchw==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.3.1.tgz",
-      "integrity": "sha512-tLpuqM46LVkduWP7JO7yVoWshpJuJzxDOPYIVWUUZbW+4dBpgGeUdl/fQkhuV0A8eGnphYw3pp8d2EnvPOfxmQ==",
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.13.1.tgz",
+      "integrity": "sha512-uxNr51CMV7npU1BxZzYjoVz9iyjckBduFBP0S5sLlh1tXYzHzgZ3BR9SVsNed+LmwKrmnqN3Kdl5t7eZ5TS1Yw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "7.3.1",
-        "@typescript-eslint/visitor-keys": "7.3.1",
+        "@typescript-eslint/types": "7.13.1",
+        "@typescript-eslint/visitor-keys": "7.13.1",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
-        "minimatch": "9.0.3",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^1.3.0"
       },
       "dependencies": {
         "brace-expansion": {
@@ -8786,9 +8652,9 @@
           }
         },
         "minimatch": {
-          "version": "9.0.3",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-          "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+          "version": "9.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+          "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
           "dev": true,
           "requires": {
             "brace-expansion": "^2.0.1"
@@ -8796,29 +8662,14 @@
         }
       }
     },
-    "@typescript-eslint/utils": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.3.1.tgz",
-      "integrity": "sha512-jIERm/6bYQ9HkynYlNZvXpzmXWZGhMbrOvq3jJzOSOlKXsVjrrolzWBjDW6/TvT5Q3WqaN4EkmcfdQwi9tDjBQ==",
-      "dev": true,
-      "requires": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "@types/json-schema": "^7.0.12",
-        "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "7.3.1",
-        "@typescript-eslint/types": "7.3.1",
-        "@typescript-eslint/typescript-estree": "7.3.1",
-        "semver": "^7.5.4"
-      }
-    },
     "@typescript-eslint/visitor-keys": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.3.1.tgz",
-      "integrity": "sha512-9RMXwQF8knsZvfv9tdi+4D/j7dMG28X/wMJ8Jj6eOHyHWwDW4ngQJcqEczSsqIKKjFiLFr40Mnr7a5ulDD3vmw==",
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.13.1.tgz",
+      "integrity": "sha512-k/Bfne7lrP7hcb7m9zSsgcBmo+8eicqqfNAJ7uUY+jkTFpKeH2FSkWpFRtimBxgkyvqfu9jTPRbYOvud6isdXA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "7.3.1",
-        "eslint-visitor-keys": "^3.4.1"
+        "@typescript-eslint/types": "7.13.1",
+        "eslint-visitor-keys": "^3.4.3"
       }
     },
     "@ungap/structured-clone": {
@@ -8828,9 +8679,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "8.11.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.0.tgz",
+      "integrity": "sha512-RTvkC4w+KNXrM39/lWCUaG0IbRkWdCv7W/IOW9oU6SawyxulvkQy5HQPVTKxEjczcUvapcrw3cFx/60VN/NRNw==",
       "dev": true
     },
     "acorn-jsx": {
@@ -8962,18 +8813,13 @@
       }
     },
     "braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "requires": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       }
-    },
-    "buffer-writer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
-      "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw=="
     },
     "callsites": {
       "version": "3.1.0",
@@ -9158,45 +9004,47 @@
       }
     },
     "conventional-changelog-angular": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz",
-      "integrity": "sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.0.0.tgz",
+      "integrity": "sha512-CLf+zr6St0wIxos4bmaKHRXWAcsCXrJU6F4VdNDrGRK3B8LDLKoX3zuMV5GhtbGkVR/LohZ6MT6im43vZLSjmA==",
       "dev": true,
       "requires": {
         "compare-func": "^2.0.0"
       }
     },
     "conventional-changelog-writer": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-7.0.1.tgz",
-      "integrity": "sha512-Uo+R9neH3r/foIvQ0MKcsXkX642hdm9odUp7TqgFS7BsalTcjzRlIfWZrZR1gbxOozKucaKt5KAbjW8J8xRSmA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-8.0.0.tgz",
+      "integrity": "sha512-TQcoYGRatlAnT2qEWDON/XSfnVG38JzA7E0wcGScu7RElQBkg9WWgZd1peCWFcWDh1xfb2CfsrcvOn1bbSzztA==",
       "dev": true,
       "requires": {
-        "conventional-commits-filter": "^4.0.0",
+        "@types/semver": "^7.5.5",
+        "conventional-commits-filter": "^5.0.0",
         "handlebars": "^4.7.7",
-        "json-stringify-safe": "^5.0.1",
-        "meow": "^12.0.1",
-        "semver": "^7.5.2",
-        "split2": "^4.0.0"
+        "meow": "^13.0.0",
+        "semver": "^7.5.2"
       }
     },
     "conventional-commits-filter": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-4.0.0.tgz",
-      "integrity": "sha512-rnpnibcSOdFcdclpFwWa+pPlZJhXE7l+XK04zxhbWrhgpR96h33QLz8hITTXbcYICxVr3HZFtbtUAQ+4LdBo9A==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
+      "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
       "dev": true
     },
     "conventional-commits-parser": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-5.0.0.tgz",
-      "integrity": "sha512-ZPMl0ZJbw74iS9LuX9YIAiW8pfM5p3yh2o/NbXHbkFuZzY5jvdi5jFycEOkmBW5H5I7nA+D6f3UcsCLP2vvSEA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.0.0.tgz",
+      "integrity": "sha512-TbsINLp48XeMXR8EvGjTnKGsZqBemisPoyWESlpRyR8lif0lcwzqz+NMtYSj1ooF/WYjSuu7wX0CtdeeMEQAmA==",
       "dev": true,
       "requires": {
-        "is-text-path": "^2.0.0",
-        "JSONStream": "^1.3.5",
-        "meow": "^12.0.1",
-        "split2": "^4.0.0"
+        "meow": "^13.0.0"
       }
+    },
+    "convert-hrtime": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-5.0.0.tgz",
+      "integrity": "sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.3",
@@ -9520,22 +9368,6 @@
           "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
           "dev": true
         },
-        "eslint-scope": {
-          "version": "7.2.2",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
-          "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
-          "dev": true,
-          "requires": {
-            "esrecurse": "^4.3.0",
-            "estraverse": "^5.2.0"
-          }
-        },
-        "estraverse": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-          "dev": true
-        },
         "find-up": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -9606,9 +9438,9 @@
       }
     },
     "eslint-plugin-sort-destructure-keys": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-sort-destructure-keys/-/eslint-plugin-sort-destructure-keys-1.5.0.tgz",
-      "integrity": "sha512-xGLyqHtbFXZNXQSvAiQ4ISBYokrbUywEhmaA50fKtSKgceCv5y3zjoNuZwcnajdM6q29Nxj+oXC9KcqfMsAPrg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-sort-destructure-keys/-/eslint-plugin-sort-destructure-keys-2.0.0.tgz",
+      "integrity": "sha512-4w1UQCa3o/YdfWaLr9jY8LfGowwjwjmwClyFLxIsToiyIdZMq3x9Ti44nDn34DtTPP7PWg96tUONKVmATKhYGQ==",
       "dev": true,
       "requires": {
         "natural-compare-lite": "^1.4.0"
@@ -9643,6 +9475,16 @@
         }
       }
     },
+    "eslint-scope": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      }
+    },
     "eslint-visitor-keys": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
@@ -9667,14 +9509,6 @@
       "dev": true,
       "requires": {
         "estraverse": "^5.1.0"
-      },
-      "dependencies": {
-        "estraverse": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-          "dev": true
-        }
       }
     },
     "esrecurse": {
@@ -9684,15 +9518,13 @@
       "dev": true,
       "requires": {
         "estraverse": "^5.2.0"
-      },
-      "dependencies": {
-        "estraverse": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-          "dev": true
-        }
       }
+    },
+    "estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true
     },
     "esutils": {
       "version": "2.0.3",
@@ -9776,9 +9608,9 @@
       }
     },
     "fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
@@ -9791,28 +9623,30 @@
       "dev": true
     },
     "find-versions": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-5.1.0.tgz",
-      "integrity": "sha512-+iwzCJ7C5v5KgcBuueqVoNiHVoQpwiUK5XFLjf0affFTep+Wcw93tPvmb8tqujDNmzhBDPddnWV/qgWSXgq+Hg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-6.0.0.tgz",
+      "integrity": "sha512-2kCCtc+JvcZ86IGAz3Z2Y0A1baIz9fL31pH/0S1IqZr9Iwnjq8izfPtrCyQKO6TLMPELLsQMre7VDqeIKCsHkA==",
       "dev": true,
       "requires": {
-        "semver-regex": "^4.0.5"
+        "semver-regex": "^4.0.5",
+        "super-regex": "^1.0.0"
       }
     },
     "flat-cache": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
-      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
       "dev": true,
       "requires": {
-        "flatted": "^3.1.0",
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.3",
         "rimraf": "^3.0.2"
       }
     },
     "flatted": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
-      "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
+      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
     },
     "from2": {
@@ -9846,6 +9680,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "function-timeout": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/function-timeout/-/function-timeout-1.0.2.tgz",
+      "integrity": "sha512-939eZS4gJ3htTHAldmyyuzlrD58P03fHG49v2JfFXbV6OhvZKRC9j2yAtdHw/zrp2zXHuv05zMIy40F0ge7spA==",
       "dev": true
     },
     "generate-function": {
@@ -10053,9 +9893,9 @@
       }
     },
     "ignore": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
+      "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
       "dev": true
     },
     "import-fresh": {
@@ -10196,6 +10036,12 @@
       "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
       "dev": true
     },
+    "is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true
+    },
     "is-property": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
@@ -10206,15 +10052,6 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "dev": true
-    },
-    "is-text-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-2.0.0.tgz",
-      "integrity": "sha512-+oDTluR6WEjdXEJMnC2z6A4FRwFoYuvShVVEGsS7ewc0UTi2QtAKMDJuL4BDEVt+5T7MjFo12RP8ghOM75oKJw==",
-      "dev": true,
-      "requires": {
-        "text-extensions": "^2.0.0"
-      }
     },
     "is-unicode-supported": {
       "version": "2.0.0",
@@ -10268,6 +10105,12 @@
         "argparse": "^2.0.1"
       }
     },
+    "json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true
+    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -10292,12 +10135,6 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "dev": true
-    },
     "jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -10308,20 +10145,13 @@
         "universalify": "^2.0.0"
       }
     },
-    "jsonparse": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
-      "dev": true
-    },
-    "JSONStream": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
-      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+    "keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
       "requires": {
-        "jsonparse": "^1.2.0",
-        "through": ">=2.2.7 <3"
+        "json-buffer": "3.0.1"
       }
     },
     "levn": {
@@ -10417,15 +10247,6 @@
       "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
       "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
     },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "requires": {
-        "yallist": "^4.0.0"
-      }
-    },
     "marked": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
@@ -10456,9 +10277,9 @@
       }
     },
     "meow": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
-      "integrity": "sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+      "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
       "dev": true
     },
     "merge-stream": {
@@ -10517,9 +10338,9 @@
       "dev": true
     },
     "mysql2": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.10.0.tgz",
-      "integrity": "sha512-qx0mfWYt1DpTPkw8mAcHW/OwqqyNqBLBHvY5IjN8+icIYTjt6znrgYJ+gxqNNRpVknb5Wc/gcCM4XjbCR0j5tw==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.10.1.tgz",
+      "integrity": "sha512-6zo1T3GILsXMCex3YEu7hCz2OXLUarxFsxvFcUHWMpkPtmZLeTTWgRdc1gWyNJiYt6AxITmIf9bZDRy/jAfWew==",
       "requires": {
         "denque": "^2.1.0",
         "generate-function": "^2.3.1",
@@ -10619,89 +10440,81 @@
       "dev": true
     },
     "npm": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-10.5.0.tgz",
-      "integrity": "sha512-Ejxwvfh9YnWVU2yA5FzoYLTW52vxHCz+MHrOFg9Cc8IFgF/6f5AGPAvb5WTay5DIUP1NIfN3VBZ0cLlGO0Ys+A==",
+      "version": "10.8.1",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-10.8.1.tgz",
+      "integrity": "sha512-Dp1C6SvSMYQI7YHq/y2l94uvI+59Eqbu1EpuKQHQ8p16txXRuRit5gH3Lnaagk2aXDIjg/Iru9pd05bnneKgdw==",
       "dev": true,
       "requires": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^7.2.1",
-        "@npmcli/config": "^8.0.2",
-        "@npmcli/fs": "^3.1.0",
-        "@npmcli/map-workspaces": "^3.0.4",
-        "@npmcli/package-json": "^5.0.0",
-        "@npmcli/promise-spawn": "^7.0.1",
-        "@npmcli/run-script": "^7.0.4",
-        "@sigstore/tuf": "^2.3.1",
+        "@npmcli/arborist": "^7.5.3",
+        "@npmcli/config": "^8.3.3",
+        "@npmcli/fs": "^3.1.1",
+        "@npmcli/map-workspaces": "^3.0.6",
+        "@npmcli/package-json": "^5.1.1",
+        "@npmcli/promise-spawn": "^7.0.2",
+        "@npmcli/redact": "^2.0.0",
+        "@npmcli/run-script": "^8.1.0",
+        "@sigstore/tuf": "^2.3.4",
         "abbrev": "^2.0.0",
         "archy": "~1.0.0",
-        "cacache": "^18.0.2",
+        "cacache": "^18.0.3",
         "chalk": "^5.3.0",
         "ci-info": "^4.0.0",
         "cli-columns": "^4.0.0",
-        "cli-table3": "^0.6.3",
-        "columnify": "^1.6.0",
         "fastest-levenshtein": "^1.0.16",
         "fs-minipass": "^3.0.3",
-        "glob": "^10.3.10",
+        "glob": "^10.4.1",
         "graceful-fs": "^4.2.11",
-        "hosted-git-info": "^7.0.1",
-        "ini": "^4.1.1",
-        "init-package-json": "^6.0.0",
-        "is-cidr": "^5.0.3",
-        "json-parse-even-better-errors": "^3.0.1",
-        "libnpmaccess": "^8.0.1",
-        "libnpmdiff": "^6.0.3",
-        "libnpmexec": "^7.0.4",
-        "libnpmfund": "^5.0.1",
-        "libnpmhook": "^10.0.0",
-        "libnpmorg": "^6.0.1",
-        "libnpmpack": "^6.0.3",
-        "libnpmpublish": "^9.0.2",
-        "libnpmsearch": "^7.0.0",
-        "libnpmteam": "^6.0.0",
-        "libnpmversion": "^5.0.1",
-        "make-fetch-happen": "^13.0.0",
-        "minimatch": "^9.0.3",
-        "minipass": "^7.0.4",
+        "hosted-git-info": "^7.0.2",
+        "ini": "^4.1.3",
+        "init-package-json": "^6.0.3",
+        "is-cidr": "^5.1.0",
+        "json-parse-even-better-errors": "^3.0.2",
+        "libnpmaccess": "^8.0.6",
+        "libnpmdiff": "^6.1.3",
+        "libnpmexec": "^8.1.2",
+        "libnpmfund": "^5.0.11",
+        "libnpmhook": "^10.0.5",
+        "libnpmorg": "^6.0.6",
+        "libnpmpack": "^7.0.3",
+        "libnpmpublish": "^9.0.9",
+        "libnpmsearch": "^7.0.6",
+        "libnpmteam": "^6.0.5",
+        "libnpmversion": "^6.0.3",
+        "make-fetch-happen": "^13.0.1",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.1",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
-        "node-gyp": "^10.0.1",
-        "nopt": "^7.2.0",
-        "normalize-package-data": "^6.0.0",
+        "node-gyp": "^10.1.0",
+        "nopt": "^7.2.1",
+        "normalize-package-data": "^6.0.1",
         "npm-audit-report": "^5.0.0",
         "npm-install-checks": "^6.3.0",
-        "npm-package-arg": "^11.0.1",
-        "npm-pick-manifest": "^9.0.0",
-        "npm-profile": "^9.0.0",
-        "npm-registry-fetch": "^16.1.0",
-        "npm-user-validate": "^2.0.0",
-        "npmlog": "^7.0.1",
+        "npm-package-arg": "^11.0.2",
+        "npm-pick-manifest": "^9.0.1",
+        "npm-profile": "^10.0.0",
+        "npm-registry-fetch": "^17.0.1",
+        "npm-user-validate": "^2.0.1",
         "p-map": "^4.0.0",
-        "pacote": "^17.0.6",
+        "pacote": "^18.0.6",
         "parse-conflict-json": "^3.0.1",
-        "proc-log": "^3.0.0",
+        "proc-log": "^4.2.0",
         "qrcode-terminal": "^0.12.0",
-        "read": "^2.1.0",
-        "semver": "^7.6.0",
-        "spdx-expression-parse": "^3.0.1",
-        "ssri": "^10.0.5",
+        "read": "^3.0.1",
+        "semver": "^7.6.2",
+        "spdx-expression-parse": "^4.0.0",
+        "ssri": "^10.0.6",
         "supports-color": "^9.4.0",
-        "tar": "^6.2.0",
+        "tar": "^6.2.1",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^1.3.0",
         "treeverse": "^3.0.0",
-        "validate-npm-package-name": "^5.0.0",
+        "validate-npm-package-name": "^5.0.1",
         "which": "^4.0.0",
         "write-file-atomic": "^5.0.1"
       },
       "dependencies": {
-        "@colors/colors": {
-          "version": "1.5.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
         "@isaacs/cliui": {
           "version": "8.0.2",
           "bundled": true,
@@ -10751,7 +10564,7 @@
           "dev": true
         },
         "@npmcli/agent": {
-          "version": "2.2.1",
+          "version": "2.2.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -10759,84 +10572,68 @@
             "http-proxy-agent": "^7.0.0",
             "https-proxy-agent": "^7.0.1",
             "lru-cache": "^10.0.1",
-            "socks-proxy-agent": "^8.0.1"
+            "socks-proxy-agent": "^8.0.3"
           }
         },
         "@npmcli/arborist": {
-          "version": "7.4.0",
+          "version": "7.5.3",
           "bundled": true,
           "dev": true,
           "requires": {
             "@isaacs/string-locale-compare": "^1.1.0",
-            "@npmcli/fs": "^3.1.0",
-            "@npmcli/installed-package-contents": "^2.0.2",
+            "@npmcli/fs": "^3.1.1",
+            "@npmcli/installed-package-contents": "^2.1.0",
             "@npmcli/map-workspaces": "^3.0.2",
-            "@npmcli/metavuln-calculator": "^7.0.0",
+            "@npmcli/metavuln-calculator": "^7.1.1",
             "@npmcli/name-from-folder": "^2.0.0",
             "@npmcli/node-gyp": "^3.0.0",
-            "@npmcli/package-json": "^5.0.0",
+            "@npmcli/package-json": "^5.1.0",
             "@npmcli/query": "^3.1.0",
-            "@npmcli/run-script": "^7.0.2",
-            "bin-links": "^4.0.1",
-            "cacache": "^18.0.0",
+            "@npmcli/redact": "^2.0.0",
+            "@npmcli/run-script": "^8.1.0",
+            "bin-links": "^4.0.4",
+            "cacache": "^18.0.3",
             "common-ancestor-path": "^1.0.1",
-            "hosted-git-info": "^7.0.1",
-            "json-parse-even-better-errors": "^3.0.0",
+            "hosted-git-info": "^7.0.2",
+            "json-parse-even-better-errors": "^3.0.2",
             "json-stringify-nice": "^1.1.4",
-            "minimatch": "^9.0.0",
-            "nopt": "^7.0.0",
+            "lru-cache": "^10.2.2",
+            "minimatch": "^9.0.4",
+            "nopt": "^7.2.1",
             "npm-install-checks": "^6.2.0",
-            "npm-package-arg": "^11.0.1",
-            "npm-pick-manifest": "^9.0.0",
-            "npm-registry-fetch": "^16.0.0",
-            "npmlog": "^7.0.1",
-            "pacote": "^17.0.4",
+            "npm-package-arg": "^11.0.2",
+            "npm-pick-manifest": "^9.0.1",
+            "npm-registry-fetch": "^17.0.1",
+            "pacote": "^18.0.6",
             "parse-conflict-json": "^3.0.0",
-            "proc-log": "^3.0.0",
+            "proc-log": "^4.2.0",
+            "proggy": "^2.0.0",
             "promise-all-reject-late": "^1.0.0",
             "promise-call-limit": "^3.0.1",
             "read-package-json-fast": "^3.0.2",
             "semver": "^7.3.7",
-            "ssri": "^10.0.5",
+            "ssri": "^10.0.6",
             "treeverse": "^3.0.0",
             "walk-up-path": "^3.0.1"
           }
         },
         "@npmcli/config": {
-          "version": "8.2.0",
+          "version": "8.3.3",
           "bundled": true,
           "dev": true,
           "requires": {
             "@npmcli/map-workspaces": "^3.0.2",
             "ci-info": "^4.0.0",
-            "ini": "^4.1.0",
-            "nopt": "^7.0.0",
-            "proc-log": "^3.0.0",
+            "ini": "^4.1.2",
+            "nopt": "^7.2.1",
+            "proc-log": "^4.2.0",
             "read-package-json-fast": "^3.0.2",
             "semver": "^7.3.5",
             "walk-up-path": "^3.0.1"
           }
         },
-        "@npmcli/disparity-colors": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.3.0"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "4.3.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "color-convert": "^2.0.1"
-              }
-            }
-          }
-        },
         "@npmcli/fs": {
-          "version": "3.1.0",
+          "version": "3.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -10844,14 +10641,14 @@
           }
         },
         "@npmcli/git": {
-          "version": "5.0.4",
+          "version": "5.0.7",
           "bundled": true,
           "dev": true,
           "requires": {
             "@npmcli/promise-spawn": "^7.0.0",
             "lru-cache": "^10.0.1",
             "npm-pick-manifest": "^9.0.0",
-            "proc-log": "^3.0.0",
+            "proc-log": "^4.0.0",
             "promise-inflight": "^1.0.1",
             "promise-retry": "^2.0.1",
             "semver": "^7.3.5",
@@ -10859,7 +10656,7 @@
           }
         },
         "@npmcli/installed-package-contents": {
-          "version": "2.0.2",
+          "version": "2.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -10868,7 +10665,7 @@
           }
         },
         "@npmcli/map-workspaces": {
-          "version": "3.0.4",
+          "version": "3.0.6",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -10879,13 +10676,14 @@
           }
         },
         "@npmcli/metavuln-calculator": {
-          "version": "7.0.0",
+          "version": "7.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
             "cacache": "^18.0.0",
             "json-parse-even-better-errors": "^3.0.0",
-            "pacote": "^17.0.0",
+            "pacote": "^18.0.0",
+            "proc-log": "^4.1.0",
             "semver": "^7.3.5"
           }
         },
@@ -10900,7 +10698,7 @@
           "dev": true
         },
         "@npmcli/package-json": {
-          "version": "5.0.0",
+          "version": "5.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -10909,12 +10707,12 @@
             "hosted-git-info": "^7.0.0",
             "json-parse-even-better-errors": "^3.0.0",
             "normalize-package-data": "^6.0.0",
-            "proc-log": "^3.0.0",
+            "proc-log": "^4.0.0",
             "semver": "^7.5.3"
           }
         },
         "@npmcli/promise-spawn": {
-          "version": "7.0.1",
+          "version": "7.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -10929,8 +10727,13 @@
             "postcss-selector-parser": "^6.0.10"
           }
         },
+        "@npmcli/redact": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
         "@npmcli/run-script": {
-          "version": "7.0.4",
+          "version": "8.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -10938,6 +10741,7 @@
             "@npmcli/package-json": "^5.0.0",
             "@npmcli/promise-spawn": "^7.0.0",
             "node-gyp": "^10.0.0",
+            "proc-log": "^4.0.0",
             "which": "^4.0.0"
           }
         },
@@ -10948,51 +10752,53 @@
           "optional": true
         },
         "@sigstore/bundle": {
-          "version": "2.2.0",
+          "version": "2.3.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@sigstore/protobuf-specs": "^0.3.0"
+            "@sigstore/protobuf-specs": "^0.3.2"
           }
         },
         "@sigstore/core": {
-          "version": "1.0.0",
+          "version": "1.1.0",
           "bundled": true,
           "dev": true
         },
         "@sigstore/protobuf-specs": {
-          "version": "0.3.0",
+          "version": "0.3.2",
           "bundled": true,
           "dev": true
         },
         "@sigstore/sign": {
-          "version": "2.2.3",
+          "version": "2.3.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@sigstore/bundle": "^2.2.0",
+            "@sigstore/bundle": "^2.3.2",
             "@sigstore/core": "^1.0.0",
-            "@sigstore/protobuf-specs": "^0.3.0",
-            "make-fetch-happen": "^13.0.0"
+            "@sigstore/protobuf-specs": "^0.3.2",
+            "make-fetch-happen": "^13.0.1",
+            "proc-log": "^4.2.0",
+            "promise-retry": "^2.0.1"
           }
         },
         "@sigstore/tuf": {
-          "version": "2.3.1",
+          "version": "2.3.4",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@sigstore/protobuf-specs": "^0.3.0",
-            "tuf-js": "^2.2.0"
+            "@sigstore/protobuf-specs": "^0.3.2",
+            "tuf-js": "^2.2.1"
           }
         },
         "@sigstore/verify": {
-          "version": "1.1.0",
+          "version": "1.2.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@sigstore/bundle": "^2.2.0",
-            "@sigstore/core": "^1.0.0",
-            "@sigstore/protobuf-specs": "^0.3.0"
+            "@sigstore/bundle": "^2.3.2",
+            "@sigstore/core": "^1.1.0",
+            "@sigstore/protobuf-specs": "^0.3.2"
           }
         },
         "@tufjs/canonical-json": {
@@ -11001,12 +10807,12 @@
           "dev": true
         },
         "@tufjs/models": {
-          "version": "2.0.0",
+          "version": "2.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
             "@tufjs/canonical-json": "2.0.0",
-            "minimatch": "^9.0.3"
+            "minimatch": "^9.0.4"
           }
         },
         "abbrev": {
@@ -11015,7 +10821,7 @@
           "dev": true
         },
         "agent-base": {
-          "version": "7.1.0",
+          "version": "7.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11051,18 +10857,13 @@
           "bundled": true,
           "dev": true
         },
-        "are-we-there-yet": {
-          "version": "4.0.2",
-          "bundled": true,
-          "dev": true
-        },
         "balanced-match": {
           "version": "1.0.2",
           "bundled": true,
           "dev": true
         },
         "bin-links": {
-          "version": "4.0.3",
+          "version": "4.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11073,7 +10874,7 @@
           }
         },
         "binary-extensions": {
-          "version": "2.2.0",
+          "version": "2.3.0",
           "bundled": true,
           "dev": true
         },
@@ -11085,16 +10886,8 @@
             "balanced-match": "^1.0.0"
           }
         },
-        "builtins": {
-          "version": "5.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "semver": "^7.0.0"
-          }
-        },
         "cacache": {
-          "version": "18.0.2",
+          "version": "18.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11128,7 +10921,7 @@
           "dev": true
         },
         "cidr-regex": {
-          "version": "4.0.3",
+          "version": "4.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11149,22 +10942,8 @@
             "strip-ansi": "^6.0.1"
           }
         },
-        "cli-table3": {
-          "version": "0.6.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@colors/colors": "1.5.0",
-            "string-width": "^4.2.0"
-          }
-        },
-        "clone": {
-          "version": "1.0.4",
-          "bundled": true,
-          "dev": true
-        },
         "cmd-shim": {
-          "version": "6.0.2",
+          "version": "6.0.3",
           "bundled": true,
           "dev": true
         },
@@ -11181,27 +10960,8 @@
           "bundled": true,
           "dev": true
         },
-        "color-support": {
-          "version": "1.1.3",
-          "bundled": true,
-          "dev": true
-        },
-        "columnify": {
-          "version": "1.6.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "strip-ansi": "^6.0.1",
-            "wcwidth": "^1.0.0"
-          }
-        },
         "common-ancestor-path": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
           "bundled": true,
           "dev": true
         },
@@ -11243,14 +11003,6 @@
               "bundled": true,
               "dev": true
             }
-          }
-        },
-        "defaults": {
-          "version": "1.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "clone": "^1.0.2"
           }
         },
         "diff": {
@@ -11319,31 +11071,16 @@
           "bundled": true,
           "dev": true
         },
-        "gauge": {
-          "version": "5.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "aproba": "^1.0.3 || ^2.0.0",
-            "color-support": "^1.1.3",
-            "console-control-strings": "^1.1.0",
-            "has-unicode": "^2.0.1",
-            "signal-exit": "^4.0.1",
-            "string-width": "^4.2.3",
-            "strip-ansi": "^6.0.1",
-            "wide-align": "^1.1.5"
-          }
-        },
         "glob": {
-          "version": "10.3.10",
+          "version": "10.4.1",
           "bundled": true,
           "dev": true,
           "requires": {
             "foreground-child": "^3.1.0",
-            "jackspeak": "^2.3.5",
-            "minimatch": "^9.0.1",
-            "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
-            "path-scurry": "^1.10.1"
+            "jackspeak": "^3.1.2",
+            "minimatch": "^9.0.4",
+            "minipass": "^7.1.2",
+            "path-scurry": "^1.11.1"
           }
         },
         "graceful-fs": {
@@ -11351,13 +11088,8 @@
           "bundled": true,
           "dev": true
         },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true
-        },
         "hasown": {
-          "version": "2.0.1",
+          "version": "2.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11365,7 +11097,7 @@
           }
         },
         "hosted-git-info": {
-          "version": "7.0.1",
+          "version": "7.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11405,7 +11137,7 @@
           }
         },
         "ignore-walk": {
-          "version": "6.0.4",
+          "version": "6.0.5",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11423,19 +11155,19 @@
           "dev": true
         },
         "ini": {
-          "version": "4.1.1",
+          "version": "4.1.3",
           "bundled": true,
           "dev": true
         },
         "init-package-json": {
-          "version": "6.0.0",
+          "version": "6.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
+            "@npmcli/package-json": "^5.0.0",
             "npm-package-arg": "^11.0.0",
             "promzard": "^1.0.0",
-            "read": "^2.0.0",
-            "read-package-json": "^7.0.0",
+            "read": "^3.0.1",
             "semver": "^7.3.5",
             "validate-npm-package-license": "^3.0.4",
             "validate-npm-package-name": "^5.0.0"
@@ -11448,13 +11180,6 @@
           "requires": {
             "jsbn": "1.1.0",
             "sprintf-js": "^1.1.3"
-          },
-          "dependencies": {
-            "sprintf-js": {
-              "version": "1.1.3",
-              "bundled": true,
-              "dev": true
-            }
           }
         },
         "ip-regex": {
@@ -11463,11 +11188,11 @@
           "dev": true
         },
         "is-cidr": {
-          "version": "5.0.3",
+          "version": "5.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "cidr-regex": "4.0.3"
+            "cidr-regex": "^4.1.1"
           }
         },
         "is-core-module": {
@@ -11494,7 +11219,7 @@
           "dev": true
         },
         "jackspeak": {
-          "version": "2.3.6",
+          "version": "3.1.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11508,7 +11233,7 @@
           "dev": true
         },
         "json-parse-even-better-errors": {
-          "version": "3.0.1",
+          "version": "3.0.2",
           "bundled": true,
           "dev": true
         },
@@ -11533,136 +11258,134 @@
           "dev": true
         },
         "libnpmaccess": {
-          "version": "8.0.2",
+          "version": "8.0.6",
           "bundled": true,
           "dev": true,
           "requires": {
-            "npm-package-arg": "^11.0.1",
-            "npm-registry-fetch": "^16.0.0"
+            "npm-package-arg": "^11.0.2",
+            "npm-registry-fetch": "^17.0.1"
           }
         },
         "libnpmdiff": {
-          "version": "6.0.7",
+          "version": "6.1.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/arborist": "^7.2.1",
-            "@npmcli/disparity-colors": "^3.0.0",
-            "@npmcli/installed-package-contents": "^2.0.2",
-            "binary-extensions": "^2.2.0",
+            "@npmcli/arborist": "^7.5.3",
+            "@npmcli/installed-package-contents": "^2.1.0",
+            "binary-extensions": "^2.3.0",
             "diff": "^5.1.0",
-            "minimatch": "^9.0.0",
-            "npm-package-arg": "^11.0.1",
-            "pacote": "^17.0.4",
-            "tar": "^6.2.0"
+            "minimatch": "^9.0.4",
+            "npm-package-arg": "^11.0.2",
+            "pacote": "^18.0.6",
+            "tar": "^6.2.1"
           }
         },
         "libnpmexec": {
-          "version": "7.0.8",
+          "version": "8.1.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/arborist": "^7.2.1",
-            "@npmcli/run-script": "^7.0.2",
+            "@npmcli/arborist": "^7.5.3",
+            "@npmcli/run-script": "^8.1.0",
             "ci-info": "^4.0.0",
-            "npm-package-arg": "^11.0.1",
-            "npmlog": "^7.0.1",
-            "pacote": "^17.0.4",
-            "proc-log": "^3.0.0",
-            "read": "^2.0.0",
+            "npm-package-arg": "^11.0.2",
+            "pacote": "^18.0.6",
+            "proc-log": "^4.2.0",
+            "read": "^3.0.1",
             "read-package-json-fast": "^3.0.2",
             "semver": "^7.3.7",
             "walk-up-path": "^3.0.1"
           }
         },
         "libnpmfund": {
-          "version": "5.0.5",
+          "version": "5.0.11",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/arborist": "^7.2.1"
+            "@npmcli/arborist": "^7.5.3"
           }
         },
         "libnpmhook": {
-          "version": "10.0.1",
+          "version": "10.0.5",
           "bundled": true,
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
-            "npm-registry-fetch": "^16.0.0"
+            "npm-registry-fetch": "^17.0.1"
           }
         },
         "libnpmorg": {
-          "version": "6.0.2",
+          "version": "6.0.6",
           "bundled": true,
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
-            "npm-registry-fetch": "^16.0.0"
+            "npm-registry-fetch": "^17.0.1"
           }
         },
         "libnpmpack": {
-          "version": "6.0.7",
+          "version": "7.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/arborist": "^7.2.1",
-            "@npmcli/run-script": "^7.0.2",
-            "npm-package-arg": "^11.0.1",
-            "pacote": "^17.0.4"
+            "@npmcli/arborist": "^7.5.3",
+            "@npmcli/run-script": "^8.1.0",
+            "npm-package-arg": "^11.0.2",
+            "pacote": "^18.0.6"
           }
         },
         "libnpmpublish": {
-          "version": "9.0.4",
+          "version": "9.0.9",
           "bundled": true,
           "dev": true,
           "requires": {
             "ci-info": "^4.0.0",
-            "normalize-package-data": "^6.0.0",
-            "npm-package-arg": "^11.0.1",
-            "npm-registry-fetch": "^16.0.0",
-            "proc-log": "^3.0.0",
+            "normalize-package-data": "^6.0.1",
+            "npm-package-arg": "^11.0.2",
+            "npm-registry-fetch": "^17.0.1",
+            "proc-log": "^4.2.0",
             "semver": "^7.3.7",
             "sigstore": "^2.2.0",
-            "ssri": "^10.0.5"
+            "ssri": "^10.0.6"
           }
         },
         "libnpmsearch": {
-          "version": "7.0.1",
+          "version": "7.0.6",
           "bundled": true,
           "dev": true,
           "requires": {
-            "npm-registry-fetch": "^16.0.0"
+            "npm-registry-fetch": "^17.0.1"
           }
         },
         "libnpmteam": {
-          "version": "6.0.1",
+          "version": "6.0.5",
           "bundled": true,
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
-            "npm-registry-fetch": "^16.0.0"
+            "npm-registry-fetch": "^17.0.1"
           }
         },
         "libnpmversion": {
-          "version": "5.0.2",
+          "version": "6.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/git": "^5.0.3",
-            "@npmcli/run-script": "^7.0.2",
-            "json-parse-even-better-errors": "^3.0.0",
-            "proc-log": "^3.0.0",
+            "@npmcli/git": "^5.0.7",
+            "@npmcli/run-script": "^8.1.0",
+            "json-parse-even-better-errors": "^3.0.2",
+            "proc-log": "^4.2.0",
             "semver": "^7.3.7"
           }
         },
         "lru-cache": {
-          "version": "10.2.0",
+          "version": "10.2.2",
           "bundled": true,
           "dev": true
         },
         "make-fetch-happen": {
-          "version": "13.0.0",
+          "version": "13.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11675,12 +11398,13 @@
             "minipass-flush": "^1.0.5",
             "minipass-pipeline": "^1.2.4",
             "negotiator": "^0.6.3",
+            "proc-log": "^4.2.0",
             "promise-retry": "^2.0.1",
             "ssri": "^10.0.0"
           }
         },
         "minimatch": {
-          "version": "9.0.3",
+          "version": "9.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11688,7 +11412,7 @@
           }
         },
         "minipass": {
-          "version": "7.0.4",
+          "version": "7.1.2",
           "bundled": true,
           "dev": true
         },
@@ -11701,7 +11425,7 @@
           }
         },
         "minipass-fetch": {
-          "version": "3.0.4",
+          "version": "3.0.5",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11824,7 +11548,7 @@
           "dev": true
         },
         "node-gyp": {
-          "version": "10.0.1",
+          "version": "10.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11838,10 +11562,17 @@
             "semver": "^7.3.5",
             "tar": "^6.1.2",
             "which": "^4.0.0"
+          },
+          "dependencies": {
+            "proc-log": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            }
           }
         },
         "nopt": {
-          "version": "7.2.0",
+          "version": "7.2.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11849,7 +11580,7 @@
           }
         },
         "normalize-package-data": {
-          "version": "6.0.0",
+          "version": "6.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11865,7 +11596,7 @@
           "dev": true
         },
         "npm-bundled": {
-          "version": "3.0.0",
+          "version": "3.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11886,12 +11617,12 @@
           "dev": true
         },
         "npm-package-arg": {
-          "version": "11.0.1",
+          "version": "11.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "hosted-git-info": "^7.0.0",
-            "proc-log": "^3.0.0",
+            "proc-log": "^4.0.0",
             "semver": "^7.3.5",
             "validate-npm-package-name": "^5.0.0"
           }
@@ -11905,7 +11636,7 @@
           }
         },
         "npm-pick-manifest": {
-          "version": "9.0.0",
+          "version": "9.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11916,43 +11647,33 @@
           }
         },
         "npm-profile": {
-          "version": "9.0.0",
+          "version": "10.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "npm-registry-fetch": "^16.0.0",
-            "proc-log": "^3.0.0"
+            "npm-registry-fetch": "^17.0.1",
+            "proc-log": "^4.0.0"
           }
         },
         "npm-registry-fetch": {
-          "version": "16.1.0",
+          "version": "17.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
+            "@npmcli/redact": "^2.0.0",
             "make-fetch-happen": "^13.0.0",
             "minipass": "^7.0.2",
             "minipass-fetch": "^3.0.0",
             "minipass-json-stream": "^1.0.1",
             "minizlib": "^2.1.2",
             "npm-package-arg": "^11.0.0",
-            "proc-log": "^3.0.0"
+            "proc-log": "^4.0.0"
           }
         },
         "npm-user-validate": {
-          "version": "2.0.0",
+          "version": "2.0.1",
           "bundled": true,
           "dev": true
-        },
-        "npmlog": {
-          "version": "7.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "are-we-there-yet": "^4.0.0",
-            "console-control-strings": "^1.1.0",
-            "gauge": "^5.0.0",
-            "set-blocking": "^2.0.0"
-          }
         },
         "p-map": {
           "version": "4.0.0",
@@ -11963,25 +11684,24 @@
           }
         },
         "pacote": {
-          "version": "17.0.6",
+          "version": "18.0.6",
           "bundled": true,
           "dev": true,
           "requires": {
             "@npmcli/git": "^5.0.0",
             "@npmcli/installed-package-contents": "^2.0.1",
+            "@npmcli/package-json": "^5.1.0",
             "@npmcli/promise-spawn": "^7.0.0",
-            "@npmcli/run-script": "^7.0.0",
+            "@npmcli/run-script": "^8.0.0",
             "cacache": "^18.0.0",
             "fs-minipass": "^3.0.0",
             "minipass": "^7.0.2",
             "npm-package-arg": "^11.0.0",
             "npm-packlist": "^8.0.0",
             "npm-pick-manifest": "^9.0.0",
-            "npm-registry-fetch": "^16.0.0",
-            "proc-log": "^3.0.0",
+            "npm-registry-fetch": "^17.0.0",
+            "proc-log": "^4.0.0",
             "promise-retry": "^2.0.1",
-            "read-package-json": "^7.0.0",
-            "read-package-json-fast": "^3.0.0",
             "sigstore": "^2.2.0",
             "ssri": "^10.0.0",
             "tar": "^6.1.11"
@@ -12003,16 +11723,16 @@
           "dev": true
         },
         "path-scurry": {
-          "version": "1.10.1",
+          "version": "1.11.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "lru-cache": "^9.1.1 || ^10.0.0",
+            "lru-cache": "^10.2.0",
             "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
           }
         },
         "postcss-selector-parser": {
-          "version": "6.0.15",
+          "version": "6.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -12021,7 +11741,12 @@
           }
         },
         "proc-log": {
-          "version": "3.0.0",
+          "version": "4.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "proggy": {
+          "version": "2.0.0",
           "bundled": true,
           "dev": true
         },
@@ -12050,11 +11775,11 @@
           }
         },
         "promzard": {
-          "version": "1.0.0",
+          "version": "1.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "read": "^2.0.0"
+            "read": "^3.0.1"
           }
         },
         "qrcode-terminal": {
@@ -12063,28 +11788,17 @@
           "dev": true
         },
         "read": {
-          "version": "2.1.0",
+          "version": "3.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "mute-stream": "~1.0.0"
+            "mute-stream": "^1.0.0"
           }
         },
         "read-cmd-shim": {
           "version": "4.0.0",
           "bundled": true,
           "dev": true
-        },
-        "read-package-json": {
-          "version": "7.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "glob": "^10.2.2",
-            "json-parse-even-better-errors": "^3.0.0",
-            "normalize-package-data": "^6.0.0",
-            "npm-normalize-package-bin": "^3.0.0"
-          }
         },
         "read-package-json-fast": {
           "version": "3.0.2",
@@ -12107,25 +11821,7 @@
           "optional": true
         },
         "semver": {
-          "version": "7.6.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          },
-          "dependencies": {
-            "lru-cache": {
-              "version": "6.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "yallist": "^4.0.0"
-              }
-            }
-          }
-        },
-        "set-blocking": {
-          "version": "2.0.0",
+          "version": "7.6.2",
           "bundled": true,
           "dev": true
         },
@@ -12148,16 +11844,16 @@
           "dev": true
         },
         "sigstore": {
-          "version": "2.2.2",
+          "version": "2.3.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@sigstore/bundle": "^2.2.0",
+            "@sigstore/bundle": "^2.3.2",
             "@sigstore/core": "^1.0.0",
-            "@sigstore/protobuf-specs": "^0.3.0",
-            "@sigstore/sign": "^2.2.3",
-            "@sigstore/tuf": "^2.3.1",
-            "@sigstore/verify": "^1.1.0"
+            "@sigstore/protobuf-specs": "^0.3.2",
+            "@sigstore/sign": "^2.3.2",
+            "@sigstore/tuf": "^2.3.4",
+            "@sigstore/verify": "^1.2.1"
           }
         },
         "smart-buffer": {
@@ -12166,7 +11862,7 @@
           "dev": true
         },
         "socks": {
-          "version": "2.8.0",
+          "version": "2.8.3",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -12175,11 +11871,11 @@
           }
         },
         "socks-proxy-agent": {
-          "version": "8.0.2",
+          "version": "8.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "agent-base": "^7.0.2",
+            "agent-base": "^7.1.1",
             "debug": "^4.3.4",
             "socks": "^2.7.1"
           }
@@ -12191,6 +11887,17 @@
           "requires": {
             "spdx-expression-parse": "^3.0.0",
             "spdx-license-ids": "^3.0.0"
+          },
+          "dependencies": {
+            "spdx-expression-parse": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+              }
+            }
           }
         },
         "spdx-exceptions": {
@@ -12199,7 +11906,7 @@
           "dev": true
         },
         "spdx-expression-parse": {
-          "version": "3.0.1",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -12208,12 +11915,17 @@
           }
         },
         "spdx-license-ids": {
-          "version": "3.0.17",
+          "version": "3.0.18",
+          "bundled": true,
+          "dev": true
+        },
+        "sprintf-js": {
+          "version": "1.1.3",
           "bundled": true,
           "dev": true
         },
         "ssri": {
-          "version": "10.0.5",
+          "version": "10.0.6",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -12262,7 +11974,7 @@
           "dev": true
         },
         "tar": {
-          "version": "6.2.0",
+          "version": "6.2.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -12315,13 +12027,13 @@
           "dev": true
         },
         "tuf-js": {
-          "version": "2.2.0",
+          "version": "2.2.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@tufjs/models": "2.0.0",
+            "@tufjs/models": "2.0.1",
             "debug": "^4.3.4",
-            "make-fetch-happen": "^13.0.0"
+            "make-fetch-happen": "^13.0.1"
           }
         },
         "unique-filename": {
@@ -12352,28 +12064,28 @@
           "requires": {
             "spdx-correct": "^3.0.0",
             "spdx-expression-parse": "^3.0.0"
+          },
+          "dependencies": {
+            "spdx-expression-parse": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+              }
+            }
           }
         },
         "validate-npm-package-name": {
-          "version": "5.0.0",
+          "version": "5.0.1",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "builtins": "^5.0.0"
-          }
+          "dev": true
         },
         "walk-up-path": {
           "version": "3.0.1",
           "bundled": true,
           "dev": true
-        },
-        "wcwidth": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "defaults": "^1.0.3"
-          }
         },
         "which": {
           "version": "4.0.0",
@@ -12388,14 +12100,6 @@
               "bundled": true,
               "dev": true
             }
-          }
-        },
-        "wide-align": {
-          "version": "1.1.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "string-width": "^1.0.2 || 2 || 3 || 4"
           }
         },
         "wrap-ansi": {
@@ -12559,11 +12263,6 @@
       "integrity": "sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw==",
       "dev": true
     },
-    "packet-reader": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
-      "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
-    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -12584,6 +12283,12 @@
         "json-parse-even-better-errors": "^2.3.0",
         "lines-and-columns": "^1.1.6"
       }
+    },
+    "parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "dev": true
     },
     "parse5": {
       "version": "5.1.1",
@@ -12633,16 +12338,14 @@
       "dev": true
     },
     "pg": {
-      "version": "8.11.3",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.11.3.tgz",
-      "integrity": "sha512-+9iuvG8QfaaUrrph+kpF24cXkH1YOOUeArRNYIxq1viYHZagBxrTno7cecY1Fa44tJeZvaoG+Djpkc3JwehN5g==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.12.0.tgz",
+      "integrity": "sha512-A+LHUSnwnxrnL/tZ+OLfqR1SxLN3c/pgDztZ47Rpbsd4jUytsTtwQo/TLPRzPJMp/1pbhYVhH9cuSZLAajNfjQ==",
       "requires": {
-        "buffer-writer": "2.0.0",
-        "packet-reader": "1.0.0",
         "pg-cloudflare": "^1.1.1",
-        "pg-connection-string": "^2.6.2",
-        "pg-pool": "^3.6.1",
-        "pg-protocol": "^1.6.0",
+        "pg-connection-string": "^2.6.4",
+        "pg-pool": "^3.6.2",
+        "pg-protocol": "^1.6.1",
         "pg-types": "^2.1.0",
         "pgpass": "1.x"
       }
@@ -12654,9 +12357,9 @@
       "optional": true
     },
     "pg-connection-string": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.2.tgz",
-      "integrity": "sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA=="
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.4.tgz",
+      "integrity": "sha512-v+Z7W/0EO707aNMaAEfiGnGL9sxxumwLl2fJvCQtMn9Fxsg+lPpPkdcyBSv/KFgpGdYkMfn+EI1Or2EHjpgLCA=="
     },
     "pg-int8": {
       "version": "1.0.1",
@@ -12669,15 +12372,15 @@
       "integrity": "sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw=="
     },
     "pg-pool": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.6.1.tgz",
-      "integrity": "sha512-jizsIzhkIitxCGfPRzJn1ZdcosIt3pz9Sh3V01fm1vZnbnCMgmGl5wvGGdNN2EL9Rmb0EcFoCkixH4Pu+sP9Og==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.6.2.tgz",
+      "integrity": "sha512-Htjbg8BlwXqSBQ9V8Vjtc+vzf/6fVUuak/3/XXKA9oxZprwW3IMDQTGHP+KDmVL7rtd+R1QjbnCFPuTHm3G4hg==",
       "requires": {}
     },
     "pg-protocol": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.0.tgz",
-      "integrity": "sha512-M+PDm637OY5WM307051+bsDia5Xej6d9IR4GwJse1qA1DIhiKlksvrneZOYQq42OM+spubpcNYEo2FcKQrDk+Q=="
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.1.tgz",
+      "integrity": "sha512-jPIlvgoD63hrEuihvIg+tJhoGjUsLPn6poJY9N5CnlPd91c2T18T/9zBtLxZSb1EhYxBRoZJtzScCaWlYLtktg=="
     },
     "pg-types": {
       "version": "2.2.0",
@@ -12806,6 +12509,15 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
     },
+    "pretty-ms": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.0.0.tgz",
+      "integrity": "sha512-E9e9HJ9R9NasGOgPaPE8VMeiPKAyWR5jcFpNnwIejslIhWqdqOrb2wShBsncMPUb+BcCd2OPYfh7p2W6oemTng==",
+      "dev": true,
+      "requires": {
+        "parse-ms": "^4.0.0"
+      }
+    },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -12842,6 +12554,25 @@
         "strip-json-comments": "~2.0.1"
       }
     },
+    "read-package-up": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-11.0.0.tgz",
+      "integrity": "sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==",
+      "dev": true,
+      "requires": {
+        "find-up-simple": "^1.0.0",
+        "read-pkg": "^9.0.0",
+        "type-fest": "^4.6.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "4.20.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.20.1.tgz",
+          "integrity": "sha512-R6wDsVsoS9xYOpy8vgeBlqpdOyzJ12HNfQhC/aAKWM3YoCV9TtunJzh/QpkMgeDhkoynDcw5f1y+qF9yc/HHyg==",
+          "dev": true
+        }
+      }
+    },
     "read-pkg": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
@@ -12866,25 +12597,6 @@
             "type-fest": "^4.7.1"
           }
         },
-        "type-fest": {
-          "version": "4.12.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.12.0.tgz",
-          "integrity": "sha512-5Y2/pp2wtJk8o08G0CMkuFPCO354FGwk/vbidxrdhRGZfd0tFnb4Qb8anp9XxXriwBgVPjdWbKpGl4J9lJY2jQ==",
-          "dev": true
-        }
-      }
-    },
-    "read-pkg-up": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-11.0.0.tgz",
-      "integrity": "sha512-LOVbvF1Q0SZdjClSefZ0Nz5z8u+tIE7mV5NibzmE9VYmDe9CaBbAVtz1veOSZbofrdsilxuDAYnFenukZVp8/Q==",
-      "dev": true,
-      "requires": {
-        "find-up-simple": "^1.0.0",
-        "read-pkg": "^9.0.0",
-        "type-fest": "^4.6.0"
-      },
-      "dependencies": {
         "type-fest": {
           "version": "4.12.0",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.12.0.tgz",
@@ -12965,23 +12677,23 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semantic-release": {
-      "version": "23.0.5",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-23.0.5.tgz",
-      "integrity": "sha512-4eZG/vRTV8E7rw5oHPv2Fht5qx6ITemE/b1vzG42ayYVcffJqXYy40nP4bHEPWX1/kleJWWrlPVDt1hSYVlpKQ==",
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-24.0.0.tgz",
+      "integrity": "sha512-v46CRPw+9eI3ZuYGF2oAjqPqsfbnfFTwLBgQsv/lch4goD09ytwOTESMN4QIrx/wPLxUGey60/NMx+ANQtWRsA==",
       "dev": true,
       "requires": {
-        "@semantic-release/commit-analyzer": "^12.0.0",
+        "@semantic-release/commit-analyzer": "^13.0.0-beta.1",
         "@semantic-release/error": "^4.0.0",
         "@semantic-release/github": "^10.0.0",
         "@semantic-release/npm": "^12.0.0",
-        "@semantic-release/release-notes-generator": "^12.0.0",
+        "@semantic-release/release-notes-generator": "^14.0.0-beta.1",
         "aggregate-error": "^5.0.0",
         "cosmiconfig": "^9.0.0",
         "debug": "^4.0.0",
         "env-ci": "^11.0.0",
-        "execa": "^8.0.0",
+        "execa": "^9.0.0",
         "figures": "^6.0.0",
-        "find-versions": "^5.1.0",
+        "find-versions": "^6.0.0",
         "get-stream": "^6.0.0",
         "git-log-parser": "^1.2.0",
         "hook-std": "^3.0.0",
@@ -12993,7 +12705,7 @@
         "micromatch": "^4.0.2",
         "p-each-series": "^3.0.0",
         "p-reduce": "^3.0.0",
-        "read-pkg-up": "^11.0.0",
+        "read-package-up": "^11.0.0",
         "resolve-from": "^5.0.0",
         "semver": "^7.3.2",
         "semver-diff": "^4.0.0",
@@ -13005,6 +12717,12 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
           "integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
+          "dev": true
+        },
+        "@sindresorhus/merge-streams": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+          "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
           "dev": true
         },
         "aggregate-error": {
@@ -13033,34 +12751,41 @@
           "dev": true
         },
         "execa": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
-          "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+          "version": "9.2.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-9.2.0.tgz",
+          "integrity": "sha512-vpOyYg7UAVKLAWWtRS2gAdgkT7oJbCn0me3gmUmxZih4kd3MF/oo8kNTBTIbkO3yuuF5uB4ZCZfn8BOolITYhg==",
           "dev": true,
           "requires": {
+            "@sindresorhus/merge-streams": "^4.0.0",
             "cross-spawn": "^7.0.3",
-            "get-stream": "^8.0.1",
-            "human-signals": "^5.0.0",
-            "is-stream": "^3.0.0",
-            "merge-stream": "^2.0.0",
-            "npm-run-path": "^5.1.0",
-            "onetime": "^6.0.0",
+            "figures": "^6.1.0",
+            "get-stream": "^9.0.0",
+            "human-signals": "^7.0.0",
+            "is-plain-obj": "^4.1.0",
+            "is-stream": "^4.0.1",
+            "npm-run-path": "^5.2.0",
+            "pretty-ms": "^9.0.0",
             "signal-exit": "^4.1.0",
-            "strip-final-newline": "^3.0.0"
+            "strip-final-newline": "^4.0.0",
+            "yoctocolors": "^2.0.0"
           },
           "dependencies": {
             "get-stream": {
-              "version": "8.0.1",
-              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
-              "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
-              "dev": true
+              "version": "9.0.1",
+              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+              "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+              "dev": true,
+              "requires": {
+                "@sec-ant/readable-stream": "^0.4.1",
+                "is-stream": "^4.0.1"
+              }
             }
           }
         },
         "human-signals": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
-          "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-7.0.0.tgz",
+          "integrity": "sha512-74kytxOUSvNbjrT9KisAbaTZ/eJwD/LrbM/kh5j0IhPuJzwuA19dWvniFGwBzN9rVjg+O/e+F310PjObDXS+9Q==",
           "dev": true
         },
         "indent-string": {
@@ -13070,9 +12795,9 @@
           "dev": true
         },
         "is-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-          "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+          "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
           "dev": true
         },
         "marked": {
@@ -13081,28 +12806,13 @@
           "integrity": "sha512-Y1/V2yafOcOdWQCX0XpAKXzDakPOpn6U0YLxTJs3cww6VxOzZV1BTOOYWLvH3gX38cq+iLwljHHTnMtlDfg01Q==",
           "dev": true
         },
-        "mimic-fn": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-          "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-          "dev": true
-        },
         "npm-run-path": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
-          "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+          "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
           "dev": true,
           "requires": {
             "path-key": "^4.0.0"
-          }
-        },
-        "onetime": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-          "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-          "dev": true,
-          "requires": {
-            "mimic-fn": "^4.0.0"
           }
         },
         "p-reduce": {
@@ -13124,21 +12834,18 @@
           "dev": true
         },
         "strip-final-newline": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-          "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+          "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
           "dev": true
         }
       }
     },
     "semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "requires": {
-        "lru-cache": "^6.0.0"
-      }
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "dev": true
     },
     "semver-diff": {
       "version": "4.0.0",
@@ -13329,6 +13036,16 @@
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
       "dev": true
     },
+    "super-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/super-regex/-/super-regex-1.0.0.tgz",
+      "integrity": "sha512-CY8u7DtbvucKuquCmOFEKhr9Besln7n9uN8eFbwcoGYWXOMW07u2o8njWaiXt11ylS3qoGF55pILjRmPlbodyg==",
+      "dev": true,
+      "requires": {
+        "function-timeout": "^1.0.1",
+        "time-span": "^5.1.0"
+      }
+    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -13397,12 +13114,6 @@
         }
       }
     },
-    "text-extensions": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-2.4.0.tgz",
-      "integrity": "sha512-te/NtwBwfiNRLf9Ijqx3T0nlqZiQ2XrrtBvu+cLL8ZRrGkO0NHTug8MYFKyoSrv/sHTaSKfilUkizV6XhxMJ3g==",
-      "dev": true
-    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -13427,11 +13138,14 @@
         "thenify": ">= 3.1.0 < 4"
       }
     },
-    "through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
-      "dev": true
+    "time-span": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/time-span/-/time-span-5.1.0.tgz",
+      "integrity": "sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==",
+      "dev": true,
+      "requires": {
+        "convert-hrtime": "^5.0.0"
+      }
     },
     "to-regex-range": {
       "version": "5.0.1",
@@ -13471,15 +13185,15 @@
       "dev": true
     },
     "typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
+      "integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
       "dev": true
     },
     "uglify-js": {
-      "version": "3.17.4",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
-      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.18.0.tgz",
+      "integrity": "sha512-SyVVbcNBCk0dzr9XL/R/ySrmYf0s372K6/hFklzgcp2lBFyXtw4I7BOdDjlLhE1aVqaI/SHWXWmYdlZxuyF38A==",
       "dev": true,
       "optional": true
     },
@@ -13621,12 +13335,6 @@
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "dev": true
     },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
-    },
     "yargs": {
       "version": "17.6.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
@@ -13654,6 +13362,12 @@
       "version": "20.2.9",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true
+    },
+    "yoctocolors": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.0.2.tgz",
+      "integrity": "sha512-Ct97huExsu7cWeEjmrXlofevF8CvzUglJ4iGUet5B8xn1oumtAZBpHU4GzYuoE6PVqcZ5hghtBrSlhwHuR1Jmw==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -45,24 +45,24 @@
   "dependencies": {
     "@js-ak/mysql-migration-system": "1.0.1",
     "@js-ak/pg-migration-system": "1.3.0",
-    "@types/pg": "8.11.2",
-    "mysql2": "3.10.0",
-    "pg": "8.11.3"
+    "@types/pg": "8.11.6",
+    "mysql2": "3.10.1",
+    "pg": "8.12.0"
   },
   "devDependencies": {
     "@semantic-release/changelog": "6.0.3",
-    "@semantic-release/commit-analyzer": "12.0.0",
+    "@semantic-release/commit-analyzer": "13.0.0",
     "@semantic-release/git": "10.0.1",
-    "@semantic-release/github": "10.0.2",
-    "@semantic-release/npm": "12.0.0",
-    "@semantic-release/release-notes-generator": "12.1.0",
-    "@types/node": "20.11.30",
-    "@typescript-eslint/eslint-plugin": "7.3.1",
-    "@typescript-eslint/parser": "7.3.1",
+    "@semantic-release/github": "10.0.6",
+    "@semantic-release/npm": "12.0.1",
+    "@semantic-release/release-notes-generator": "14.0.1",
+    "@types/node": "20.14.8",
+    "@typescript-eslint/eslint-plugin": "7.13.1",
+    "@typescript-eslint/parser": "7.13.1",
     "eslint": "8.57.0",
-    "eslint-plugin-sort-destructure-keys": "1.5.0",
+    "eslint-plugin-sort-destructure-keys": "2.0.0",
     "eslint-plugin-sort-exports": "0.9.1",
-    "semantic-release": "23.0.5",
-    "typescript": "5.4.5"
+    "semantic-release": "24.0.0",
+    "typescript": "5.5.2"
   }
 }

--- a/src/test/PG-03/user/model/model.ts
+++ b/src/test/PG-03/user/model/model.ts
@@ -35,24 +35,14 @@ export class Model extends PG.BaseModel {
 			"ur.title     AS ur_title",
 		];
 
-		const {
-			orderByFields,
-			paginationFields,
-			searchFields,
-			selectedFields,
-		} = this.getFieldsToSearch(
+		const data = this.getFieldsToSearch(
 			{ queryArray },
 			selected,
 			pagination,
 			order,
 		);
 
-		return (await this.pool.query(queries.getList(
-			orderByFields,
-			paginationFields,
-			searchFields,
-			selectedFields,
-		), values)).rows;
+		return (await this.pool.query(queries.getList(data), values)).rows;
 	}
 
 }
@@ -74,19 +64,19 @@ const tableFields: TableKeys[] = [
 
 // ----- queries -----------------------
 const queries = {
-	getList(
-		orderByFields: string,
-		paginationFields: string,
-		searchFields: string,
-		selectedFields: string,
-	) {
+	getList(payload: {
+		orderByFields: string;
+		paginationFields: string;
+		searchFields: string;
+		selectedFields: string;
+	}) {
 		return `
-			SELECT ${selectedFields}
+			SELECT ${payload.selectedFields}
 			FROM ${tableName} u
 			JOIN user_roles ur ON ur.id = u.id_user_role
-			${searchFields}
-			${orderByFields}
-			${paginationFields}
+			${payload.searchFields}
+			${payload.orderByFields}
+			${payload.paginationFields}
 		`;
 	},
 };


### PR DESCRIPTION
bump @types/pg to 8.11.6
bump mysql2 to 3.10.1
bump pg to 8.12.0
bump @semantic-release/commit-analyzer to 13.0.0
bump @semantic-release/git to 10.0.1
bump @semantic-release/github to 10.0.6
bump @semantic-release/npm to 12.0.1
bump @semantic-release/release-notes-generator to 14.0.1 bump @types/node to 20.14.8
bump @typescript-eslint/eslint-plugin to 7.13.1
bump @typescript-eslint/parser to 7.13.1
bump eslint-plugin-sort-destructure-keys to 2.0.0
bump semantic-release to 24.0.0
bump typescript to 5.5.2